### PR TITLE
defaults, constructors and collects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A split vector is a vector represented as a sequence of multiple contagious data fragments which avoids copies while growing and preserves the memory location of its elements."
@@ -10,4 +10,5 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures"]
 
 [dependencies]
+orx-fixed-vec = "0.3.2"
 orx-pinned-vec = "0.4.2"

--- a/src/fragment/eq.rs
+++ b/src/fragment/eq.rs
@@ -1,4 +1,6 @@
-use crate::Fragment;
+use crate::{Fragment, Growth, SplitVec};
+use orx_fixed_vec::FixedVec;
+use orx_pinned_vec::PinnedVec;
 
 impl<T: PartialEq, U> PartialEq<U> for Fragment<T>
 where
@@ -22,5 +24,11 @@ impl<T: PartialEq> PartialEq<Fragment<T>> for Vec<T> {
 impl<T: PartialEq, const N: usize> PartialEq<Fragment<T>> for [T; N] {
     fn eq(&self, other: &Fragment<T>) -> bool {
         self.as_slice() == other.data
+    }
+}
+
+impl<T: PartialEq, G: Growth> PartialEq<SplitVec<T, G>> for FixedVec<T> {
+    fn eq(&self, other: &SplitVec<T, G>) -> bool {
+        self.len() == other.len() && self.iter().zip(other.iter()).all(|(x, y)| x == y)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@
 //!
 //! ```rust
 //! use orx_split_vec::prelude::*;
-//! use std::rc::Rc;
 //! #[derive(Clone)]
 //! pub struct DoubleEverySecondFragment(usize); // any custom growth strategy
 //! impl Growth for DoubleEverySecondFragment {

--- a/src/new_split_vec/from.rs
+++ b/src/new_split_vec/from.rs
@@ -1,5 +1,4 @@
-use crate::{Doubling, Exponential, Growth, Linear, SplitVec};
-use orx_pinned_vec::{NotSelfRefVecItem, PinnedVec};
+use crate::{Doubling, Exponential, Linear, SplitVec};
 
 // into SplitVec
 impl<T> From<Vec<T>> for SplitVec<T, Linear> {
@@ -82,78 +81,3 @@ impl<T> From<Vec<T>> for SplitVec<T, Exponential> {
 }
 
 // from SplitVec
-impl<T, G> From<SplitVec<T, G>> for Vec<T>
-where
-    G: Growth,
-    T: NotSelfRefVecItem,
-{
-    /// Converts the `SplitVec` into a standard `Vec` with a contagious memory layout.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use orx_split_vec::prelude::*;
-    ///
-    /// let mut split_vec = SplitVec::with_linear_growth(4);
-    /// split_vec.extend_from_slice(&['a', 'b', 'c']);
-    ///
-    /// assert_eq!(1, split_vec.fragments().len());
-    ///
-    /// let vec: Vec<_> = split_vec.into();
-    /// assert_eq!(vec, &['a', 'b', 'c']);
-    ///
-    /// let mut split_vec = SplitVec::with_linear_growth(4);
-    /// for i in 0..10 {
-    ///     split_vec.push(i);
-    /// }
-    /// assert_eq!(&[0, 1, 2, 3], split_vec.fragments()[0].as_slice());
-    /// assert_eq!(&[4, 5, 6, 7], split_vec.fragments()[1].as_slice());
-    /// assert_eq!(&[8, 9], split_vec.fragments()[2].as_slice());
-    ///
-    /// let vec: Vec<_> = split_vec.into();
-    /// assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], vec.as_slice());
-    /// ```
-    fn from(mut value: SplitVec<T, G>) -> Self {
-        let mut vec = vec![];
-        vec.reserve(value.len());
-        for f in &mut value.fragments {
-            vec.append(&mut f.data);
-        }
-        vec
-    }
-}
-impl<T, G> SplitVec<T, G>
-where
-    G: Growth,
-    T: NotSelfRefVecItem,
-{
-    /// Converts the `SplitVec` into a standard `Vec` with a contagious memory layout.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use orx_split_vec::prelude::*;
-    ///
-    /// let mut split_vec = SplitVec::with_linear_growth(4);
-    /// split_vec.extend_from_slice(&['a', 'b', 'c']);
-    ///
-    /// assert_eq!(1, split_vec.fragments().len());
-    ///
-    /// let vec = split_vec.to_vec();
-    /// assert_eq!(vec, &['a', 'b', 'c']);
-    ///
-    /// let mut split_vec = SplitVec::with_linear_growth(4);
-    /// for i in 0..10 {
-    ///     split_vec.push(i);
-    /// }
-    /// assert_eq!(&[0, 1, 2, 3], split_vec.fragments()[0].as_slice());
-    /// assert_eq!(&[4, 5, 6, 7], split_vec.fragments()[1].as_slice());
-    /// assert_eq!(&[8, 9], split_vec.fragments()[2].as_slice());
-    ///
-    /// let vec = split_vec.to_vec();
-    /// assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], vec.as_slice());
-    /// ```
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-}

--- a/src/new_split_vec/into.rs
+++ b/src/new_split_vec/into.rs
@@ -1,0 +1,149 @@
+use crate::{Growth, SplitVec};
+use orx_fixed_vec::FixedVec;
+use orx_pinned_vec::{NotSelfRefVecItem, PinnedVec};
+
+// std::vec::vec
+impl<T, G> From<SplitVec<T, G>> for Vec<T>
+where
+    G: Growth,
+    T: NotSelfRefVecItem,
+{
+    /// Converts the `SplitVec` into a standard `Vec` with a contagious memory layout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_split_vec::prelude::*;
+    ///
+    /// let mut split_vec = SplitVec::with_linear_growth(4);
+    /// split_vec.extend_from_slice(&['a', 'b', 'c']);
+    ///
+    /// assert_eq!(1, split_vec.fragments().len());
+    ///
+    /// let vec: Vec<_> = split_vec.into();
+    /// assert_eq!(vec, &['a', 'b', 'c']);
+    ///
+    /// let mut split_vec = SplitVec::with_linear_growth(4);
+    /// for i in 0..10 {
+    ///     split_vec.push(i);
+    /// }
+    /// assert_eq!(&[0, 1, 2, 3], split_vec.fragments()[0].as_slice());
+    /// assert_eq!(&[4, 5, 6, 7], split_vec.fragments()[1].as_slice());
+    /// assert_eq!(&[8, 9], split_vec.fragments()[2].as_slice());
+    ///
+    /// let vec: Vec<_> = split_vec.into();
+    /// assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], vec.as_slice());
+    /// ```
+    fn from(mut value: SplitVec<T, G>) -> Self {
+        let mut vec = vec![];
+        vec.reserve(value.len());
+        for f in &mut value.fragments {
+            vec.append(&mut f.data);
+        }
+        vec
+    }
+}
+
+impl<T, G> SplitVec<T, G>
+where
+    G: Growth,
+    T: NotSelfRefVecItem,
+{
+    /// Converts the `SplitVec` into a standard `Vec` with a contagious memory layout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_split_vec::prelude::*;
+    ///
+    /// let mut split_vec = SplitVec::with_linear_growth(4);
+    /// split_vec.extend_from_slice(&['a', 'b', 'c']);
+    ///
+    /// assert_eq!(1, split_vec.fragments().len());
+    ///
+    /// let vec = split_vec.to_vec();
+    /// assert_eq!(vec, &['a', 'b', 'c']);
+    ///
+    /// let mut split_vec = SplitVec::with_linear_growth(4);
+    /// for i in 0..10 {
+    ///     split_vec.push(i);
+    /// }
+    /// assert_eq!(&[0, 1, 2, 3], split_vec.fragments()[0].as_slice());
+    /// assert_eq!(&[4, 5, 6, 7], split_vec.fragments()[1].as_slice());
+    /// assert_eq!(&[8, 9], split_vec.fragments()[2].as_slice());
+    ///
+    /// let vec = split_vec.to_vec();
+    /// assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], vec.as_slice());
+    /// ```
+    pub fn to_vec(self) -> Vec<T> {
+        self.into()
+    }
+}
+
+// orx_fixed_vec::FixedVec
+impl<T, G> SplitVec<T, G>
+where
+    G: Growth,
+    T: NotSelfRefVecItem + Clone,
+{
+    /// Collects the split vector into a fixed vector
+    /// with a fixed capacity being exactly equal to the length of this split vector.
+    ///
+    /// # Safety
+    ///
+    /// Since `T: NotSelfRefVecItem`, it is safe to clone the data of the elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_split_vec::prelude::*;
+    ///
+    /// // SplitVec with dynamic capacity and configurable growth strategy.
+    /// let mut split = SplitVec::with_linear_growth(32);
+    /// for i in 0..35 {
+    ///     split.push(i);
+    /// }
+    /// assert_eq!(35, split.len());
+    /// assert_eq!(2, split.fragments().len());
+    /// assert_eq!(32, split.fragments()[0].len());
+    /// assert_eq!(3, split.fragments()[1].len());
+    ///
+    /// // FixedVec with std::vec::Vec complexity & performance.
+    /// let fixed = split.collect_fixed_vec();
+    /// assert_eq!(35, fixed.len());
+    /// assert_eq!(fixed, split);
+    /// ```
+    pub fn collect_fixed_vec(&self) -> FixedVec<T> {
+        unsafe { self.unsafe_collect_fixed_vec() }
+    }
+}
+impl<T, G> SplitVec<T, G>
+where
+    G: Growth,
+    T: Clone,
+{
+    /// Collects the split vector into a fixed vector
+    /// with a fixed capacity being exactly equal to the length of this split vector.
+    ///
+    /// # Safety
+    ///
+    /// Since `T` is not a `NotSelfRefVecItem`, it is assumed as a `SelfRefVecItem`
+    /// to be conservative. A naive clone of a vector of `SelfRefVecItem` elements
+    /// is unsafe due to the following scenario:
+    ///
+    /// * say the vector contains two elements `['a', 'b']` where `'a'` holds a reference to `'b'`.
+    /// * when we clone this vector, element `'a'` of the second vector will be pointing to
+    /// element `'b'` of the first vector, which is already incorrect.
+    /// * furthermore, if the first vector is dropped, the abovementioned reference will be
+    /// an dangling reference leading to UB.
+    ///
+    /// Therefore, cloning elements of a vector where elements are not `NotSelfRefVecItem`
+    /// is `unsafe`.
+    pub unsafe fn unsafe_collect_fixed_vec(&self) -> FixedVec<T> {
+        let mut fixed = FixedVec::new(self.len());
+        for fragment in &self.fragments {
+            fixed.extend_from_slice(&fragment.data);
+        }
+        fixed
+    }
+}

--- a/src/new_split_vec/mod.rs
+++ b/src/new_split_vec/mod.rs
@@ -1,3 +1,4 @@
 mod default;
 mod from;
+mod into;
 mod new;

--- a/src/new_split_vec/new.rs
+++ b/src/new_split_vec/new.rs
@@ -1,14 +1,135 @@
-use crate::{Fragment, Growth, SplitVec};
+use crate::{Doubling, Fragment, Growth, SplitVec};
+
+impl<T> SplitVec<T> {
+    /// Creates an empty split vector with default growth strategy.
+    ///
+    /// Default growth strategy is `Doubling` with initial capacity of 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_split_vec::*;
+    ///
+    /// let vec: SplitVec<f32> = SplitVec::new();
+    ///
+    /// assert_eq!(1, vec.fragments().len());
+    /// assert_eq!(4, vec.fragments()[0].capacity());
+    /// ```
+    pub fn new() -> Self {
+        let growth = Doubling;
+        let capacity = Growth::new_fragment_capacity::<T>(&growth, &[]);
+        let fragment = Fragment::new(capacity);
+        let fragments = vec![fragment];
+        Self { fragments, growth }
+    }
+    /// Creates an empty split vector with default growth strategy.
+    ///
+    /// Default growth strategy is `Doubling` with the given `initial_capacity`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_split_vec::*;
+    ///
+    /// let vec: SplitVec<f32> = SplitVec::with_initial_capacity(8);
+    ///
+    /// assert_eq!(1, vec.fragments().len());
+    /// assert_eq!(8, vec.fragments()[0].capacity());
+    /// ```
+    pub fn with_initial_capacity(initial_capacity: usize) -> Self {
+        Self::with_doubling_growth(initial_capacity)
+    }
+}
 
 impl<T, G> SplitVec<T, G>
 where
     G: Growth,
 {
     /// Creates an empty split vector with the given `growth` strategy.
+    ///
+    /// This constructor is especially useful to define custom growth strategies.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_split_vec::prelude::*;
+    ///
+    /// #[derive(Clone)]
+    /// pub struct DoubleEverySecondFragment(usize); // any custom growth strategy
+    /// impl Growth for DoubleEverySecondFragment {
+    ///     fn new_fragment_capacity<T>(&self, fragments: &[Fragment<T>]) -> usize {
+    ///         fragments
+    ///             .last()
+    ///             .map(|f| {
+    ///                 let do_double = fragments.len() % 2 == 0;
+    ///                 if do_double {
+    ///                     f.capacity() * 2
+    ///                 } else {
+    ///                     f.capacity()
+    ///                 }
+    ///             })
+    ///             .unwrap_or(self.0)
+    ///     }
+    /// }
+    /// let mut vec = SplitVec::with_growth(DoubleEverySecondFragment(8));
+    /// for i in 0..17 {
+    ///     vec.push(i);
+    /// }
+    ///
+    /// assert_eq!(3, vec.fragments().len());
+    ///
+    /// assert_eq!(8, vec.fragments()[0].capacity());
+    /// assert_eq!(8, vec.fragments()[0].len());
+    ///
+    /// assert_eq!(8, vec.fragments()[1].capacity());
+    /// assert_eq!(8, vec.fragments()[1].len());
+    ///
+    /// assert_eq!(16, vec.fragments()[2].capacity());
+    /// assert_eq!(1, vec.fragments()[2].len());
+    /// ```
     pub fn with_growth(growth: G) -> Self {
         let capacity = Growth::new_fragment_capacity::<T>(&growth, &[]);
         let fragment = Fragment::new(capacity);
         let fragments = vec![fragment];
         Self { fragments, growth }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Exponential, Linear};
+
+    #[test]
+    fn new() {
+        let vec: SplitVec<usize> = SplitVec::new();
+        let vec: SplitVec<usize, Doubling> = vec;
+
+        assert_eq!(1, vec.fragments().len());
+        assert_eq!(4, vec.fragments()[0].capacity());
+    }
+
+    #[test]
+    fn with_initial_capacity() {
+        let vec: SplitVec<usize> = SplitVec::with_initial_capacity(32);
+        let vec: SplitVec<usize, Doubling> = vec;
+
+        assert_eq!(1, vec.fragments().len());
+        assert_eq!(32, vec.fragments()[0].capacity());
+    }
+
+    #[test]
+    fn with_growth() {
+        let vec: SplitVec<char, Linear> = SplitVec::with_growth(Linear);
+        assert_eq!(1, vec.fragments().len());
+        assert_eq!(32, vec.fragments()[0].capacity());
+
+        let vec: SplitVec<char, Doubling> = SplitVec::with_growth(Doubling);
+        assert_eq!(1, vec.fragments().len());
+        assert_eq!(4, vec.fragments()[0].capacity());
+
+        let vec: SplitVec<char, Exponential> = SplitVec::with_growth(Exponential::new(1.25));
+        assert_eq!(1, vec.fragments().len());
+        assert_eq!(4, vec.fragments()[0].capacity());
     }
 }

--- a/src/split_vec.rs
+++ b/src/split_vec.rs
@@ -1,4 +1,4 @@
-use crate::{fragment::fragment_struct::Fragment, Growth};
+use crate::{fragment::fragment_struct::Fragment, Doubling, Growth};
 
 /// A split vector; i.e., a vector of fragments, with the following features:
 ///
@@ -6,7 +6,7 @@ use crate::{fragment::fragment_struct::Fragment, Growth};
 /// * Growth does not cause any memory copies.
 /// * Capacity of an already created fragment is never changed.
 /// * The above feature allows the data to stay pinned in place. Memory location of an item added to the split vector will never change unless it is removed from the vector or the vector is dropped.
-pub struct SplitVec<T, G>
+pub struct SplitVec<T, G = Doubling>
 where
     G: Growth,
 {


### PR DESCRIPTION
* default growth type is set as `Doubling` to make it possible to avoid the second type parameter.
* equality with `FixedVec` is implemented.
* safe and unsafe versions of `collect_fixed_vec` iare implemented.
* `SplitVec::new()` is implemented.
* `SplitVec::with_initial_capacity` is implemented.