### PR TITLE
dependency to orx_fixed_vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient dynamic capacity vector with pinned elements."
@@ -10,7 +10,6 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures"]
 
 [dependencies]
-orx-fixed-vec = "0.4"
 orx-pinned-vec = "0.5"
 
 

--- a/src/fragment/eq.rs
+++ b/src/fragment/eq.rs
@@ -1,6 +1,4 @@
-use crate::{Fragment, Growth, SplitVec};
-use orx_fixed_vec::FixedVec;
-use orx_pinned_vec::PinnedVec;
+use crate::Fragment;
 
 impl<T: PartialEq, U> PartialEq<U> for Fragment<T>
 where
@@ -24,11 +22,5 @@ impl<T: PartialEq> PartialEq<Fragment<T>> for Vec<T> {
 impl<T: PartialEq, const N: usize> PartialEq<Fragment<T>> for [T; N] {
     fn eq(&self, other: &Fragment<T>) -> bool {
         self.as_slice() == other.data
-    }
-}
-
-impl<T: PartialEq, G: Growth> PartialEq<SplitVec<T, G>> for FixedVec<T> {
-    fn eq(&self, other: &SplitVec<T, G>) -> bool {
-        self.len() == other.len() && self.iter().zip(other.iter()).all(|(x, y)| x == y)
     }
 }

--- a/src/new_split_vec/into.rs
+++ b/src/new_split_vec/into.rs
@@ -1,5 +1,4 @@
 use crate::{Growth, SplitVec};
-use orx_fixed_vec::FixedVec;
 use orx_pinned_vec::{NotSelfRefVecItem, PinnedVec};
 
 // std::vec::vec
@@ -77,74 +76,5 @@ where
     /// ```
     pub fn to_vec(self) -> Vec<T> {
         self.into()
-    }
-}
-
-// orx_fixed_vec::FixedVec
-impl<T, G> SplitVec<T, G>
-where
-    G: Growth,
-    T: NotSelfRefVecItem + Clone,
-{
-    /// Collects the split vector into a fixed vector
-    /// with a fixed capacity being exactly equal to the length of this split vector.
-    ///
-    /// # Safety
-    ///
-    /// Since `T: NotSelfRefVecItem`, it is safe to clone the data of the elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use orx_split_vec::prelude::*;
-    ///
-    /// // SplitVec with dynamic capacity and configurable growth strategy.
-    /// let mut split = SplitVec::with_linear_growth(5);
-    /// for i in 0..35 {
-    ///     split.push(i);
-    /// }
-    /// assert_eq!(35, split.len());
-    /// assert_eq!(2, split.fragments().len());
-    /// assert_eq!(32, split.fragments()[0].len());
-    /// assert_eq!(3, split.fragments()[1].len());
-    ///
-    /// // FixedVec with std::vec::Vec complexity & performance.
-    /// let fixed = split.collect_fixed_vec();
-    /// assert_eq!(35, fixed.len());
-    /// assert_eq!(fixed, split);
-    /// ```
-    pub fn collect_fixed_vec(&self) -> FixedVec<T> {
-        unsafe { self.unsafe_collect_fixed_vec() }
-    }
-}
-
-impl<T, G> SplitVec<T, G>
-where
-    G: Growth,
-    T: Clone,
-{
-    /// Collects the split vector into a fixed vector
-    /// with a fixed capacity being exactly equal to the length of this split vector.
-    ///
-    /// # Safety
-    ///
-    /// Since `T` is not a `NotSelfRefVecItem`, it is assumed as a `SelfRefVecItem`
-    /// to be conservative. A naive clone of a vector of `SelfRefVecItem` elements
-    /// is unsafe due to the following scenario:
-    ///
-    /// * say the vector contains two elements `['a', 'b']` where `'a'` holds a reference to `'b'`.
-    /// * when we clone this vector, element `'a'` of the second vector will be pointing to
-    /// element `'b'` of the first vector, which is already incorrect.
-    /// * furthermore, if the first vector is dropped, the abovementioned reference will be
-    /// an dangling reference leading to UB.
-    ///
-    /// Therefore, cloning elements of a vector where elements are not `NotSelfRefVecItem`
-    /// is `unsafe`.
-    pub unsafe fn unsafe_collect_fixed_vec(&self) -> FixedVec<T> {
-        let mut fixed = FixedVec::new(self.len());
-        for fragment in &self.fragments {
-            fixed.extend_from_slice(&fragment.data);
-        }
-        fixed
     }
 }


### PR DESCRIPTION
Dependency to orx_fixed_vec::FixedVec is removed. This is due to the fact that split vector performs as well as the standard vec after the performance optimizations, currently making fixed-vec not necessary.