### PR TITLE
GrowthWithConstantTimeAccess and ptr_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ The capacity of the new fragment is determined by the chosen growth strategy. As
 
 `C` is set on initialization as a power of two for `Linear` strategy, and it is fixed to 4 for `Doubling` strategy to allow for access time optimizations.
 
-In addition there exists the `Recursive` growth strategy, which behaves as the `Doubling` strategy at the beginning. However, it allows for zero-cost `append` operation at the expense of a reduced random access time performance. Please see the <a href="#section-benchmarks">E. Benchmarks</a> section for tradeoffs and details. The summary is as follows:
+In addition there exists the `Recursive` growth strategy, which behaves as the `Doubling` strategy at the beginning. However, it allows for zero-cost `append` operation at the expense of a reduced random access time performance.
+
+Growth strategies which allow for constant time random access additionally implement the `GrowthWithConstantTimeAccess` trait, which are currently `Doubling` and `Linear` strategies.
+
+Please see the <a href="#section-benchmarks">E. Benchmarks</a> section for tradeoffs and details. The summary is as follows:
 
 * Use `SplitVec<T, Doubling>` (or equivalently `SplitVec<T>`)
   * when it is required to have pinned elements and we need close to standard vector serial and random access performance, or

--- a/benches/append.rs
+++ b/benches/append.rs
@@ -34,7 +34,7 @@ fn calc_split_vec_extend<G: Growth>(
     mut vectors: Vectors,
 ) -> SplitVec<usize, G> {
     for x in &mut vectors.0 {
-        vec.extend_from_slice(&x);
+        vec.extend_from_slice(x);
         x.clear();
     }
     vec

--- a/src/common_traits/index.rs
+++ b/src/common_traits/index.rs
@@ -6,6 +6,7 @@ where
     G: Growth,
 {
     type Output = T;
+
     /// Returns a reference to the `index`-th item of the vector.
     ///
     /// # Panics
@@ -71,6 +72,7 @@ where
     G: Growth,
 {
     type Output = T;
+
     /// One can treat the split vector as a jagged array
     /// and access an item with (fragment_index, inner_fragment_index)
     /// if these numbers are known.

--- a/src/growth/growth_trait.rs
+++ b/src/growth/growth_trait.rs
@@ -5,8 +5,8 @@ pub trait Growth: Clone {
     /// Given that the split vector contains the given `fragments`,
     /// returns the capacity of the next fragment.
     fn new_fragment_capacity<T>(&self, fragments: &[Fragment<T>]) -> usize;
-    /// Returns the location of the element with the given `element_index` on the split vector
-    /// as a tuple of (fragment-index, index-within-fragment).
+
+    /// Returns the location of the element with the given `element_index` on the split vector as a tuple of (fragment-index, index-within-fragment).
     ///
     /// Returns None if the element index is out of bounds.
     fn get_fragment_and_inner_indices<T>(
@@ -26,4 +26,15 @@ pub trait Growth: Clone {
         }
         None
     }
+}
+
+/// Growth strategy of a split vector which allows for constant time access to the elements.
+pub trait GrowthWithConstantTimeAccess: Growth {
+    /// Returns the location of the element with the given `element_index` on the split vector as a tuple of (fragment-index, index-within-fragment).
+    ///
+    /// Notice that unlike the [`Growth::get_fragment_and_inner_indices`]:
+    /// * this method does not receive the current state of the split vector,
+    /// * therefore, it does not perform bounds check,
+    /// * and hence, returns the expected fragment and within-fragment indices for any index computed by the constant access time function.
+    fn get_fragment_and_inner_indices_unchecked(&self, element_index: usize) -> (usize, usize);
 }

--- a/src/growth/linear/linear_growth.rs
+++ b/src/growth/linear/linear_growth.rs
@@ -1,8 +1,8 @@
-use crate::growth::growth_trait::Growth;
+use crate::growth::growth_trait::{Growth, GrowthWithConstantTimeAccess};
 use crate::growth::linear::constants::FIXED_CAPACITIES;
 use crate::{Fragment, SplitVec};
 
-/// Stategy which allows the split vector to grow linearly.
+/// Strategy which allows the split vector to grow linearly.
 ///
 /// In other words, each new fragment will have equal capacity,
 /// which is equal to the capacity of the first fragment.
@@ -73,6 +73,14 @@ impl Growth for Linear {
     }
 }
 
+impl GrowthWithConstantTimeAccess for Linear {
+    fn get_fragment_and_inner_indices_unchecked(&self, element_index: usize) -> (usize, usize) {
+        let f = element_index >> self.constant_fragment_capacity_exponent;
+        let i = element_index % self.constant_fragment_capacity;
+        (f, i)
+    }
+}
+
 impl<T> SplitVec<T, Linear> {
     /// Creates a split vector with linear growth where each fragment will have a capacity of `2 ^ constant_fragment_capacity_exponent`.
     ///
@@ -120,5 +128,21 @@ impl<T> SplitVec<T, Linear> {
             growth: Linear::new(constant_fragment_capacity_exponent),
             len: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_fragment_and_inner_indices_unchecked() {
+        let growth = Linear::new(2);
+
+        assert_eq!((0, 0), growth.get_fragment_and_inner_indices_unchecked(0));
+        assert_eq!((0, 1), growth.get_fragment_and_inner_indices_unchecked(1));
+        assert_eq!((1, 0), growth.get_fragment_and_inner_indices_unchecked(4));
+        assert_eq!((2, 1), growth.get_fragment_and_inner_indices_unchecked(9));
+        assert_eq!((4, 0), growth.get_fragment_and_inner_indices_unchecked(16));
     }
 }

--- a/src/growth/recursive/recursive_growth.rs
+++ b/src/growth/recursive/recursive_growth.rs
@@ -49,7 +49,7 @@ impl Growth for Recursive {
 }
 
 impl<T> SplitVec<T, Recursive> {
-    /// Stategy which allows to create a fragment with double the capacity
+    /// Strategy which allows to create a fragment with double the capacity
     /// of the prior fragment every time the split vector needs to expand.
     ///
     /// Notice that this is similar to the `Doubling` growth strategy.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,11 @@
 //!
 //! `C` is set on initialization as a power of two for `Linear` strategy, and it is fixed to 4 for `Doubling` strategy to allow for access time optimizations.
 //!
-//! In addition there exists the `Recursive` growth strategy, which behaves as the `Doubling` strategy at the beginning. However, it allows for zero-cost `append` operation at the expense of a reduced random access time performance. Please see the <a href="#section-benchmarks">E. Benchmarks</a> section for tradeoffs and details. The summary is as follows:
+//! In addition there exists the `Recursive` growth strategy, which behaves as the `Doubling` strategy at the beginning. However, it allows for zero-cost `append` operation at the expense of a reduced random access time performance.
+//!
+//! Growth strategies which allow for constant time random access additionally implement the `GrowthWithConstantTimeAccess` trait, which are currently `Doubling` and `Linear` strategies.
+//!
+//! Please see the <a href="#section-benchmarks">E. Benchmarks</a> section for tradeoffs and details. The summary is as follows:
 //!
 //! * Use `SplitVec<T, Doubling>` (or equivalently `SplitVec<T>`)
 //!   * when it is required to have pinned elements and we need close to standard vector serial and random access performance, or
@@ -284,10 +288,15 @@ pub(crate) mod test;
 pub use common_traits::iterator::iter::Iter;
 pub use fragment::fragment_struct::Fragment;
 pub use fragment::into_fragments::IntoFragments;
-pub use growth::{doubling::Doubling, growth_trait::Growth, linear::Linear, recursive::Recursive};
+pub use growth::{
+    doubling::Doubling,
+    growth_trait::{Growth, GrowthWithConstantTimeAccess},
+    linear::Linear,
+    recursive::Recursive,
+};
 pub use slice::SplitVecSlice;
 pub use split_vec::SplitVec;
 
 /// The split-vec prelude, along with the `SplitVec`, imports
-/// various growth startegies, iterators and finally the `orx_pinned_vec::PinnedVec` trait.
+/// various growth strategies, iterators and finally the `orx_pinned_vec::PinnedVec` trait.
 pub mod prelude;


### PR DESCRIPTION
* `GrowthWithConstantTimeAccess` trait is defined. Note that every type implementing this trait also implements `Growth`. In other words, this is a special growth case. In addition, it provides the function `get_fragment_and_inner_indices_unchecked` which returns fragment and within-fragment indices without requiring the current state of the vector using constant time access function.
* `ptr_mut` method is implemented for split vectors having a constant time access growth strategy. This method is unsafe in the sense that it allows reading from or writing to uninitialized memory. On the other hand, it is safe against access violation, it only returns a memory location owned by the split vector.