### PR TITLE
SplitVec is extended by try_grow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.3"
+orx-pinned-vec = "2.4"
 
 [[bench]]
 name = "serial_access"

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -1,3 +1,5 @@
+use orx_pinned_vec::PinnedVec;
+
 use crate::{Growth, SplitVec};
 use std::fmt::Debug;
 
@@ -7,11 +9,16 @@ where
     G: Growth,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "SplitVec [")?;
+        writeln!(
+            f,
+            "SplitVec {{ len: {}, capacity:{}, data: [",
+            self.len(),
+            self.capacity()
+        )?;
         for frag in &self.fragments {
             writeln!(f, "    {:?}", frag)?;
         }
-        writeln!(f, "]")
+        writeln!(f, "] }}")
     }
 }
 
@@ -28,7 +35,7 @@ mod tests {
 
         let debug_str = format!("{:?}", vec);
         assert_eq!(
-            "SplitVec [\n    [0, 1, 2, 3]\n    [4, 5, 6, 7, 8, 9, 10, 11]\n    [12]\n]\n",
+            "SplitVec { len: 13, capacity:28, data: [\n    [0, 1, 2, 3]\n    [4, 5, 6, 7, 8, 9, 10, 11]\n    [12]\n] }\n",
             debug_str
         );
     }

--- a/src/common_traits/iterator/from_iter.rs
+++ b/src/common_traits/iterator/from_iter.rs
@@ -16,14 +16,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Doubling, Linear, SplitVec};
+    use crate::{Doubling, Recursive, SplitVec};
 
     #[test]
     fn collect() {
         let vec = SplitVec::<_, Doubling>::from_iter([0, 1, 2, 3, 4, 5]);
-        assert_eq!(&vec, &[0, 1, 2, 3, 4, 5]);
-
-        let vec = SplitVec::<_, Linear>::from_iter([0, 1, 2, 3, 4, 5]);
         assert_eq!(&vec, &[0, 1, 2, 3, 4, 5]);
 
         let vec = SplitVec::<_>::from_iter([0, 1, 2, 3, 4, 5]);
@@ -32,7 +29,7 @@ mod tests {
         let vec: SplitVec<_, Doubling> = (0..6).collect();
         assert_eq!(&vec, &[0, 1, 2, 3, 4, 5]);
 
-        let vec: SplitVec<_, Linear> = (0..6).collect();
+        let vec: SplitVec<_, Recursive> = (0..6).collect();
         assert_eq!(&vec, &[0, 1, 2, 3, 4, 5]);
 
         let vec: SplitVec<_> = (0..6).collect();
@@ -44,7 +41,7 @@ mod tests {
         let vec: SplitVec<_, Doubling> = (0..6).filter(|x| x % 2 == 0).collect();
         assert_eq!(&vec, &[0, 2, 4]);
 
-        let vec: SplitVec<_, Linear> = (0..6).filter(|x| x % 2 == 0).collect();
+        let vec: SplitVec<_, Recursive> = (0..6).filter(|x| x % 2 == 0).collect();
         assert_eq!(&vec, &[0, 2, 4]);
     }
 }

--- a/src/fragment/fragment_struct.rs
+++ b/src/fragment/fragment_struct.rs
@@ -8,6 +8,7 @@
 pub struct Fragment<T> {
     pub(crate) data: Vec<T>,
 }
+
 impl<T> Fragment<T> {
     /// Creates a new fragment with the given `capacity` and pushes already the `first_value`.
     pub fn new_with_first_value(capacity: usize, first_value: T) -> Self {
@@ -15,16 +16,19 @@ impl<T> Fragment<T> {
         data.push(first_value);
         Self { data }
     }
+
     /// Creates a new fragment with the given `capacity`.
     pub fn new(capacity: usize) -> Self {
         Self {
             data: Vec::with_capacity(capacity),
         }
     }
+
     /// Returns whether the fragment has room to push a new item or not.
     pub fn has_capacity_for_one(&self) -> bool {
         self.data.len() < self.data.capacity()
     }
+
     /// Returns the available capacity in the fragment.
     pub fn room(&self) -> usize {
         self.data.capacity() - self.data.len()

--- a/src/growth/linear/linear_growth.rs
+++ b/src/growth/linear/linear_growth.rs
@@ -36,7 +36,7 @@ use crate::{Fragment, SplitVec};
 /// assert_eq!(Some(16), vec.fragments().last().map(|f| f.capacity()));
 /// assert_eq!(Some(1), vec.fragments().last().map(|f| f.len()));
 /// ```
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Linear {
     constant_fragment_capacity_exponent: usize,
     constant_fragment_capacity: usize,


### PR DESCRIPTION
* `try_grow` is implemented. Note that all split vector variants have the capability to grow. Therefore, they will grow and return Ok of the new capacity provided that the vector has reached its capacity.
* Debug text is extended by length and capacity.
* `Default` is un-implemented for `Linear`.