### PR TITLE
Support for Concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.5"
+orx-pinned-vec = "2.6"
 
 [[bench]]
 name = "serial_access"

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ An efficient constant access time vector with dynamic capacity and pinned elemen
 
 There are various situations where pinned elements are necessary.
 
-* It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details.
-* It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` avoids heap allocations and wide pointers such as `Box` or `Rc` or etc.
-* It is important for **async** code; following [blog](https://blog.cloudflare.com/pin-and-unpin-in-rust) could be useful for the interested.
-
-*As explained in [rust-docs](https://doc.rust-lang.org/std/pin/index.html), there exist `Pin` and `Unpin` types for similar purposes. However, the solution is complicated and low level using `PhantomPinned`, `NonNull`, `dangling`, `Box::pin`, pointer accesses, etc.*
+* It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+* It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
+* It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 
 ## B. Comparison with `FixedVec`
 
@@ -21,7 +19,7 @@ There are various situations where pinned elements are necessary.
 
 | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol`.     | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol`.         |
+| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
 | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |

--- a/src/common_traits/clone.rs
+++ b/src/common_traits/clone.rs
@@ -1,4 +1,5 @@
 use crate::{Growth, SplitVec};
+use orx_pinned_vec::PinnedVec;
 
 impl<T, G> Clone for SplitVec<T, G>
 where
@@ -6,19 +7,50 @@ where
     G: Growth,
 {
     fn clone(&self) -> Self {
-        let fragments: Vec<_> = self
-            .fragments
-            .iter()
-            .map(|fragment| {
-                let mut vec = Vec::with_capacity(fragment.capacity());
-                vec.extend_from_slice(fragment);
-                vec.into()
-            })
-            .collect();
-        Self {
-            fragments,
-            len: self.len,
-            growth: self.growth.clone(),
+        let mut fragments = Vec::with_capacity(self.fragments.capacity());
+
+        for fragment in &self.fragments {
+            let mut vec = Vec::with_capacity(fragment.capacity());
+            vec.extend_from_slice(fragment);
+            fragments.push(vec.into());
         }
+
+        Self::from_raw_parts(self.len(), fragments, self.growth().clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    #[test]
+    fn clone() {
+        fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+            for i in 0..168 {
+                vec.push(i);
+            }
+
+            let clone = vec.clone();
+
+            assert_eq!(vec.len(), clone.len());
+            assert_eq!(vec.fragments().len(), clone.fragments().len());
+            assert_eq!(vec.capacity(), clone.capacity());
+            assert_eq!(vec.capacity_state(), clone.capacity_state());
+            assert_eq!(
+                vec.maximum_concurrent_capacity(),
+                clone.maximum_concurrent_capacity()
+            );
+
+            for (a, b) in vec.fragments().iter().zip(clone.fragments().iter()) {
+                assert_eq!(a.len(), b.len());
+                assert_eq!(a.capacity(), b.capacity());
+
+                for (x, y) in a.iter().zip(b.iter()) {
+                    assert_eq!(x, y);
+                }
+            }
+        }
+
+        test_all_growth_types!(test);
     }
 }

--- a/src/fragment/fragment_struct.rs
+++ b/src/fragment/fragment_struct.rs
@@ -33,4 +33,28 @@ impl<T> Fragment<T> {
     pub fn room(&self) -> usize {
         self.data.capacity() - self.data.len()
     }
+
+    // helpers
+    pub(crate) fn fragments_with_default_capacity() -> Vec<Fragment<T>> {
+        Vec::new()
+    }
+
+    pub(crate) fn into_fragments(self) -> Vec<Fragment<T>> {
+        let mut fragments = Self::fragments_with_default_capacity();
+        fragments.push(self);
+        fragments
+    }
+
+    pub(crate) fn fragments_with_capacity(fragments_capacity: usize) -> Vec<Fragment<T>> {
+        Vec::with_capacity(fragments_capacity)
+    }
+
+    pub(crate) fn into_fragments_with_capacity(
+        self,
+        fragments_capacity: usize,
+    ) -> Vec<Fragment<T>> {
+        let mut fragments = Self::fragments_with_capacity(fragments_capacity);
+        fragments.push(self);
+        fragments
+    }
 }

--- a/src/growth/doubling/from.rs
+++ b/src/growth/doubling/from.rs
@@ -49,10 +49,6 @@ impl<T: Clone> From<Vec<T>> for SplitVec<T, Doubling> {
             curr_f += 1;
         }
 
-        Self {
-            fragments,
-            growth: Doubling,
-            len: 123,
-        }
+        Self::from_raw_parts(len, fragments, Doubling)
     }
 }

--- a/src/growth/linear/from.rs
+++ b/src/growth/linear/from.rs
@@ -29,10 +29,8 @@ impl<T> From<Vec<T>> for SplitVec<T, Linear> {
             .find(|(_, fixed_cap)| **fixed_cap > len)
             .map(|(f, _)| f)
             .expect("overflow");
-        Self {
-            fragments: vec![value.into()],
-            growth: Linear::new(f),
-            len,
-        }
+        let growth = Linear::new(f);
+        let fragments = vec![value.into()];
+        Self::from_raw_parts(len, fragments, growth)
     }
 }

--- a/src/growth/linear/linear_growth.rs
+++ b/src/growth/linear/linear_growth.rs
@@ -84,6 +84,24 @@ impl Growth for Linear {
     unsafe fn get_ptr_mut<T>(&self, fragments: &mut [Fragment<T>], index: usize) -> Option<*mut T> {
         <Self as GrowthWithConstantTimeAccess>::get_ptr_mut(self, fragments, index)
     }
+
+    fn maximum_concurrent_capacity<T>(
+        &self,
+        fragments: &[Fragment<T>],
+        fragments_capacity: usize,
+    ) -> usize {
+        assert!(fragments_capacity >= fragments.len());
+
+        fragments_capacity * self.constant_fragment_capacity
+    }
+
+    fn required_fragments_len<T>(&self, _: &[Fragment<T>], maximum_capacity: usize) -> usize {
+        let num_full_fragments = maximum_capacity / self.constant_fragment_capacity;
+        let remainder = maximum_capacity % self.constant_fragment_capacity;
+        let additional_fragment = if remainder > 0 { 1 } else { 0 };
+
+        num_full_fragments + additional_fragment
+    }
 }
 
 impl GrowthWithConstantTimeAccess for Linear {
@@ -135,18 +153,43 @@ impl<T> SplitVec<T, Linear> {
     /// ```
     pub fn with_linear_growth(constant_fragment_capacity_exponent: usize) -> Self {
         assert!(constant_fragment_capacity_exponent > 0);
+
         let constant_fragment_capacity = FIXED_CAPACITIES[constant_fragment_capacity_exponent];
-        Self {
-            fragments: vec![Fragment::new(constant_fragment_capacity)],
-            growth: Linear::new(constant_fragment_capacity_exponent),
-            len: 0,
-        }
+        let fragments = Fragment::new(constant_fragment_capacity).into_fragments();
+        let growth = Linear::new(constant_fragment_capacity_exponent);
+        Self::from_raw_parts(0, fragments, growth)
+    }
+
+    /// Creates a new split vector with `Linear` growth and initial `fragments_capacity`.
+    ///
+    /// This method differs from [`SplitVec::with_linear_growth`] only by the pre-allocation of fragments collection.
+    /// Note that this (only) important for concurrent programs:
+    /// * SplitVec already keeps all elements pinned to their locations;
+    /// * Creating a buffer for storing the meta information is important for keeping the meta information pinned as well.
+    /// This is relevant and important for concurrent programs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fragments_capacity == 0`.
+    pub fn with_linear_growth_and_fragments_capacity(
+        constant_fragment_capacity_exponent: usize,
+        fragments_capacity: usize,
+    ) -> Self {
+        assert!(constant_fragment_capacity_exponent > 0);
+        assert!(fragments_capacity > 0);
+
+        let constant_fragment_capacity = FIXED_CAPACITIES[constant_fragment_capacity_exponent];
+        let fragments = Fragment::new(constant_fragment_capacity)
+            .into_fragments_with_capacity(fragments_capacity);
+        let growth = Linear::new(constant_fragment_capacity_exponent);
+        Self::from_raw_parts(0, fragments, growth)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};
 
     #[test]
     fn get_fragment_and_inner_indices() {
@@ -202,5 +245,147 @@ mod tests {
             assert_eq!(Some((f, i)), get(index));
             assert_eq!(None, get_none(index));
         }
+    }
+
+    #[test]
+    fn maximum_concurrent_capacity() {
+        fn max_cap<T>(vec: &SplitVec<T, Linear>) -> usize {
+            vec.growth()
+                .maximum_concurrent_capacity(vec.fragments(), vec.fragments.capacity())
+        }
+
+        let mut vec: SplitVec<char, Linear> = SplitVec::with_linear_growth(5);
+        assert_eq!(max_cap(&vec), 4 * 2usize.pow(5));
+
+        let until = max_cap(&vec);
+        for _ in 0..until {
+            vec.push('x');
+            assert_eq!(max_cap(&vec), 4 * 2usize.pow(5));
+        }
+
+        // fragments allocate beyond max_cap
+        vec.push('x');
+        assert_eq!(max_cap(&vec), 8 * 2usize.pow(5));
+    }
+
+    #[test]
+    fn with_linear_growth() {
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth(10);
+
+        assert_eq!(4, vec.fragments.capacity());
+
+        for _ in 0..100_000 {
+            vec.push('x');
+        }
+
+        assert!(vec.fragments.capacity() > 4);
+
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth(10);
+        let result = unsafe { vec.grow_to(100_000) };
+        assert!(result.is_ok());
+        assert!(result.expect("is-ok") >= 100_000);
+    }
+
+    #[test]
+    fn with_linear_growth_and_fragments_capacity_normal_growth() {
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth_and_fragments_capacity(10, 1);
+
+        assert_eq!(1, vec.fragments.capacity());
+
+        for _ in 0..100_000 {
+            vec.push('x');
+        }
+
+        assert!(vec.fragments.capacity() > 4);
+    }
+
+    #[test]
+    fn with_linear_growth_and_fragments_capacity_concurrent_grow_never() {
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth_and_fragments_capacity(10, 1);
+
+        assert!(!vec.can_concurrently_add_fragment());
+
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        assert_eq!(
+            result,
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+        );
+    }
+
+    #[test]
+    fn with_linear_growth_and_fragments_capacity_concurrent_grow_once() {
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth_and_fragments_capacity(10, 2);
+
+        assert!(vec.can_concurrently_add_fragment());
+
+        let next_capacity = vec.capacity() + vec.growth().new_fragment_capacity(vec.fragments());
+
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        assert_eq!(result, Ok(next_capacity));
+
+        assert!(!vec.can_concurrently_add_fragment());
+
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        assert_eq!(
+            result,
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+        );
+    }
+
+    #[test]
+    fn with_linear_growth_and_fragments_capacity_concurrent_grow_twice() {
+        // when possible
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth_and_fragments_capacity(10, 3);
+
+        assert!(vec.can_concurrently_add_fragment());
+
+        let fragment_2_capacity = vec.growth().new_fragment_capacity(vec.fragments());
+        let fragment_3_capacity = fragment_2_capacity;
+        let new_capacity = vec.capacity() + fragment_2_capacity + fragment_3_capacity;
+
+        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1) };
+        assert_eq!(result, Ok(new_capacity));
+
+        assert!(!vec.can_concurrently_add_fragment());
+
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        assert_eq!(
+            result,
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+        );
+
+        // when not possible
+        let mut vec: SplitVec<char, _> = SplitVec::with_linear_growth_and_fragments_capacity(10, 2);
+
+        assert!(vec.can_concurrently_add_fragment()); // although we can add one fragment
+
+        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1) }; // we cannot add two
+        assert_eq!(
+            result,
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn with_linear_growth_and_fragments_capacity_zero() {
+        let _: SplitVec<char, _> = SplitVec::with_linear_growth_and_fragments_capacity(10, 0);
+    }
+
+    #[test]
+    fn required_fragments_len() {
+        let vec: SplitVec<char, Linear> = SplitVec::with_linear_growth(5);
+        let num_fragments = |max_cap| {
+            vec.growth()
+                .required_fragments_len(vec.fragments(), max_cap)
+        };
+
+        assert_eq!(num_fragments(0), 0);
+        assert_eq!(num_fragments(1), 1);
+        assert_eq!(num_fragments(2), 1);
+        assert_eq!(num_fragments(32), 1);
+        assert_eq!(num_fragments(33), 2);
+        assert_eq!(num_fragments(32 * 7), 7);
+        assert_eq!(num_fragments(32 * 7 + 1), 8);
     }
 }

--- a/src/growth/recursive/from.rs
+++ b/src/growth/recursive/from.rs
@@ -23,11 +23,7 @@ impl<T> From<SplitVec<T, Doubling>> for SplitVec<T, Recursive> {
     /// assert_eq!(split_vec_recursive, &['a', 'b', 'c']);
     /// ```
     fn from(value: SplitVec<T, Doubling>) -> Self {
-        Self {
-            len: value.len,
-            fragments: value.fragments,
-            growth: Recursive,
-        }
+        Self::from_raw_parts(value.len, value.fragments, Recursive)
     }
 }
 
@@ -54,11 +50,7 @@ impl<T> From<SplitVec<T, Linear>> for SplitVec<T, Recursive> {
     /// assert_eq!(split_vec_recursive, &['a', 'b', 'c']);
     /// ```
     fn from(value: SplitVec<T, Linear>) -> Self {
-        Self {
-            len: value.len,
-            fragments: value.fragments,
-            growth: Recursive,
-        }
+        Self::from_raw_parts(value.len, value.fragments, Recursive)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,9 @@ mod split_vec;
 #[cfg(test)]
 pub(crate) mod test;
 
+/// Common relevant traits, structs, enums.
+pub mod prelude;
+
 pub use common_traits::iterator::iter::Iter;
 pub use fragment::fragment_struct::Fragment;
 pub use fragment::into_fragments::IntoFragments;

--- a/src/new_split_vec/default.rs
+++ b/src/new_split_vec/default.rs
@@ -1,4 +1,4 @@
-use crate::{fragment::fragment_struct::Fragment, Growth, SplitVec};
+use crate::{Growth, SplitVec};
 
 impl<T, G> Default for SplitVec<T, G>
 where
@@ -6,14 +6,6 @@ where
 {
     /// Creates an empty split vector with the default `FragmentGrowth` strategy.
     fn default() -> Self {
-        let growth = G::default();
-        let capacity = Growth::new_fragment_capacity::<T>(&growth, &[]);
-        let fragment = Fragment::new(capacity);
-        let fragments = vec![fragment];
-        Self {
-            fragments,
-            growth,
-            len: 0,
-        }
+        Self::with_growth(G::default())
     }
 }

--- a/src/new_split_vec/new.rs
+++ b/src/new_split_vec/new.rs
@@ -70,11 +70,7 @@ where
         let capacity = Growth::new_fragment_capacity::<T>(&growth, &[]);
         let fragment = Fragment::new(capacity);
         let fragments = vec![fragment];
-        Self {
-            fragments,
-            growth,
-            len: 0,
-        }
+        SplitVec::from_raw_parts(0, fragments, growth)
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,5 @@
+pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
+
 pub use crate::common_traits::iterator::iter::Iter;
 pub use crate::fragment::fragment_struct::Fragment;
 pub use crate::fragment::into_fragments::IntoFragments;
@@ -9,4 +11,3 @@ pub use crate::growth::{
 };
 pub use crate::slice::SplitVecSlice;
 pub use crate::split_vec::SplitVec;
-pub use orx_pinned_vec::PinnedVec;


### PR DESCRIPTION
* Split vector is revised for supporting data structures which use it as the underlying storage in a concurrent program:
  * `maximum_concurrent_capacity` method is implemented to the vector. Even though the vector can grow beyond this value, it must not grow beyond it in a concurrent program. The underlying reason is due to a possible re-allocation of the `fragments` collection. Split vector will always keep the elements pinned to their memory locations. However, as we keep adding fragments to the fragments collection, the memory locations of the meta information (pointers to the fragments) might be changed. This is completely fine in a single threaded program since the pinned elements guarantee is not broken. However, in a concurrent program, this might lead to the corresponding UB: * a thread tries to increase the capacity of the split vector. * this might lead to re-allocation of the fragments collection to a different memory location. * concurrently, another thread might be reading from the older memory location which is UB.
  * `concurrent_reserve` method is implemented. This method naturally requires a `&mut self` reference. Therefore, it can safely grow the maximum capacity to the desired value. Note that this call is not costly as it does not lead to any immediate allocations, except for memory to store the pointers to the fragments.
  * internal `can_concurrently_add_fragment` method is implemented to make sure that concurrent safety guarantees are satisfied.
  * `concurrently_grow_to` method is implemented. This method returns a result stating whether or not it is safely possible to grow the capacity to the desired value in a concurrent setting.
  * `capacity_state` method is implemented. This method may be considered as the detailed version of the `capacity` method. The additional information is useful for concurrent safety guarantees.
  * Capacity related tests are extended.
  * New constructors with allowing guaranteed maximum capacity are implemented:
    * `with_linear_growth_and_fragments_capacity`
    * `with_doubling_growth_and_fragments_capacity` * `with_recursive_growth_and_fragments_capacity`
  * `Growth::required_fragments_len` trait method is defined with an auto implementation. Efficient implementations are provided for the growth strategies defined in this crate.
  * `clone` method now preserves equality of `maximum_capacity`.
* `prelude` module is brought back.
* Internal `SplitVec` and `Fragment` constructors are revised and simplified.