### PR TITLE
grow_to methods accepts `zero_memory` argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.7.1"
+version = "2.8.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.6"
+orx-pinned-vec = "2.7"
 
 [[bench]]
 name = "serial_access"
@@ -20,3 +20,4 @@ harness = false
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = "0.8"
 rand_chacha = "0.3"
+test-case = "3.3.1"

--- a/src/fragment/fragment_struct.rs
+++ b/src/fragment/fragment_struct.rs
@@ -57,4 +57,27 @@ impl<T> Fragment<T> {
         fragments.push(self);
         fragments
     }
+
+    /// Zeroes out all memory; i.e., positions in `0..fragment.capacity()`, of the fragment.
+    #[inline(always)]
+    pub(crate) unsafe fn zero(&mut self) {
+        let slice = std::slice::from_raw_parts_mut(self.data.as_mut_ptr(), self.capacity());
+        slice.iter_mut().for_each(|m| *m = std::mem::zeroed());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zeroed() {
+        let mut fragment: Fragment<i32> = Fragment::new(4);
+        unsafe { fragment.zero() };
+        unsafe { fragment.set_len(4) };
+        let zero: i32 = unsafe { std::mem::zeroed() };
+        for i in 0..4 {
+            assert_eq!(fragment.get(i), Some(&zero));
+        }
+    }
 }

--- a/src/growth/doubling/doubling_growth.rs
+++ b/src/growth/doubling/doubling_growth.rs
@@ -203,9 +203,9 @@ impl<T> SplitVec<T, Doubling> {
 
 #[cfg(test)]
 mod tests {
-    use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};
-
     use super::*;
+    use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};
+    use test_case::test_matrix;
 
     #[test]
     fn get_fragment_and_inner_indices() {
@@ -284,8 +284,8 @@ mod tests {
         assert_eq!(max_cap(&vec), 4 + 8 + 16 + 32 + 64 + 128 + 256 + 512);
     }
 
-    #[test]
-    fn with_doubling_growth() {
+    #[test_matrix([true, false])]
+    fn with_doubling_growth(zero_memory: bool) {
         let mut vec: SplitVec<char, _> = SplitVec::with_doubling_growth();
 
         assert_eq!(4, vec.fragments.capacity());
@@ -297,9 +297,8 @@ mod tests {
         assert!(vec.fragments.capacity() > 4);
 
         let mut vec: SplitVec<char, _> = SplitVec::with_doubling_growth();
-        let result = unsafe { vec.grow_to(100_000) };
-        assert!(result.is_ok());
-        assert!(result.expect("is-ok") >= 100_000);
+        let result = unsafe { vec.grow_to(100_000, zero_memory) };
+        assert!(result.expect("must-be-ok") >= 100_000);
     }
 
     #[test]
@@ -315,41 +314,41 @@ mod tests {
         assert!(vec.fragments.capacity() > 4);
     }
 
-    #[test]
-    fn with_doubling_growth_and_fragments_capacity_concurrent_grow_never() {
+    #[test_matrix([true, false])]
+    fn with_doubling_growth_and_fragments_capacity_concurrent_grow_never(zero_memory: bool) {
         let mut vec: SplitVec<char, _> = SplitVec::with_doubling_growth_and_fragments_capacity(1);
 
         assert!(!vec.can_concurrently_add_fragment());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         );
     }
 
-    #[test]
-    fn with_doubling_growth_and_fragments_capacity_concurrent_grow_once() {
+    #[test_matrix([true, false])]
+    fn with_doubling_growth_and_fragments_capacity_concurrent_grow_once(zero_memory: bool) {
         let mut vec: SplitVec<char, _> = SplitVec::with_doubling_growth_and_fragments_capacity(2);
 
         assert!(vec.can_concurrently_add_fragment());
 
         let next_capacity = vec.capacity() + vec.growth().new_fragment_capacity(vec.fragments());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(result, Ok(next_capacity));
 
         assert!(!vec.can_concurrently_add_fragment());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         );
     }
 
-    #[test]
-    fn with_doubling_growth_and_fragments_capacity_concurrent_grow_twice() {
+    #[test_matrix([true, false])]
+    fn with_doubling_growth_and_fragments_capacity_concurrent_grow_twice(zero_memory: bool) {
         // when possible
         let mut vec: SplitVec<char, _> = SplitVec::with_doubling_growth_and_fragments_capacity(3);
 
@@ -359,12 +358,12 @@ mod tests {
         let fragment_3_capacity = fragment_2_capacity * 2;
         let new_capacity = vec.capacity() + fragment_2_capacity + fragment_3_capacity;
 
-        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1) };
+        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1, zero_memory) };
         assert_eq!(result, Ok(new_capacity));
 
         assert!(!vec.can_concurrently_add_fragment());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
@@ -375,7 +374,7 @@ mod tests {
 
         assert!(vec.can_concurrently_add_fragment()); // although we can add one fragment
 
-        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1) }; // we cannot add two
+        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1, zero_memory) }; // we cannot add two
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)

--- a/src/growth/recursive/recursive_growth.rs
+++ b/src/growth/recursive/recursive_growth.rs
@@ -184,6 +184,7 @@ impl<T> SplitVec<T, Recursive> {
 mod tests {
     use super::*;
     use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};
+    use test_case::test_matrix;
 
     #[test]
     fn get_fragment_and_inner_indices() {
@@ -297,8 +298,8 @@ mod tests {
         assert_eq!(max_cap(&vec), 4 + 10 + 20 + 40);
     }
 
-    #[test]
-    fn with_recursive_growth() {
+    #[test_matrix([true, false])]
+    fn with_recursive_growth(zero_memory: bool) {
         let mut vec: SplitVec<char, _> = SplitVec::with_recursive_growth();
 
         assert_eq!(4, vec.fragments.capacity());
@@ -310,7 +311,7 @@ mod tests {
         assert!(vec.fragments.capacity() > 4);
 
         let mut vec: SplitVec<char, _> = SplitVec::with_recursive_growth();
-        let result = unsafe { vec.grow_to(100_000) };
+        let result = unsafe { vec.grow_to(100_000, zero_memory) };
         assert!(result.is_ok());
         assert!(result.expect("is-ok") >= 100_000);
     }
@@ -328,41 +329,41 @@ mod tests {
         assert!(vec.fragments.capacity() > 4);
     }
 
-    #[test]
-    fn with_recursive_growth_and_fragments_capacity_concurrent_grow_never() {
+    #[test_matrix([true, false])]
+    fn with_recursive_growth_and_fragments_capacity_concurrent_grow_never(zero_memory: bool) {
         let mut vec: SplitVec<char, _> = SplitVec::with_recursive_growth_and_fragments_capacity(1);
 
         assert!(!vec.can_concurrently_add_fragment());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         );
     }
 
-    #[test]
-    fn with_recursive_growth_and_fragments_capacity_concurrent_grow_once() {
+    #[test_matrix([true, false])]
+    fn with_recursive_growth_and_fragments_capacity_concurrent_grow_once(zero_memory: bool) {
         let mut vec: SplitVec<char, _> = SplitVec::with_recursive_growth_and_fragments_capacity(2);
 
         assert!(vec.can_concurrently_add_fragment());
 
         let next_capacity = vec.capacity() + vec.growth().new_fragment_capacity(vec.fragments());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(result, Ok(next_capacity));
 
         assert!(!vec.can_concurrently_add_fragment());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         );
     }
 
-    #[test]
-    fn with_recursive_growth_and_fragments_capacity_concurrent_grow_twice() {
+    #[test_matrix([true, false])]
+    fn with_recursive_growth_and_fragments_capacity_concurrent_grow_twice(zero_memory: bool) {
         // when possible
         let mut vec: SplitVec<char, _> = SplitVec::with_recursive_growth_and_fragments_capacity(3);
 
@@ -372,12 +373,12 @@ mod tests {
         let fragment_3_capacity = fragment_2_capacity * 2;
         let new_capacity = vec.capacity() + fragment_2_capacity + fragment_3_capacity;
 
-        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1) };
+        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1, zero_memory) };
         assert_eq!(result, Ok(new_capacity));
 
         assert!(!vec.can_concurrently_add_fragment());
 
-        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1) };
+        let result = unsafe { vec.concurrently_grow_to(vec.capacity() + 1, zero_memory) };
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
@@ -388,7 +389,7 @@ mod tests {
 
         assert!(vec.can_concurrently_add_fragment()); // although we can add one fragment
 
-        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1) }; // we cannot add two
+        let result = unsafe { vec.concurrently_grow_to(new_capacity - 1, zero_memory) }; // we cannot add two
         assert_eq!(
             result,
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)


### PR DESCRIPTION
The users of the PinnedVec trait, hence SplitVec, might require to zero out allocated memory which is not yet written. This is an additional safety guarantee for specifically concurrent data types. Therefore, grow_to and concurrently_grow_to methods accept a second argument zero_memory. When true is passed in, the implementor is responsible for zeroing out the new memory, if allocated.

* `Fragment::zero(&mut self)` method is implemented. This method is used on new fragments when grow to methods are called with a `zero_memory` of true.
* growth with memory zeroing tests are added.
* Tests extended with the `test-case` crate.