### PR TITLE
Efficient Reductions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."

--- a/src/common_traits/iterator/mod.rs
+++ b/src/common_traits/iterator/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod iter;
 pub(crate) mod iter_mut;
 pub(crate) mod iter_mut_rev;
 pub(crate) mod iter_rev;
+mod reductions;
 
 #[cfg(test)]
 mod tests;

--- a/src/common_traits/iterator/reductions.rs
+++ b/src/common_traits/iterator/reductions.rs
@@ -1,0 +1,54 @@
+use crate::Fragment;
+use std::slice::Iter;
+
+type Outer<'a, T> = Iter<'a, Fragment<T>>;
+type Inner<'a, T> = Iter<'a, T>;
+
+pub fn all<'a, T, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, mut f: F) -> bool
+where
+    F: FnMut(&'a T) -> bool,
+{
+    for x in inner {
+        if !f(x) {
+            return false;
+        }
+    }
+    for fragment in outer {
+        for x in fragment.iter() {
+            if !f(x) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+pub fn any<'a, T, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, mut f: F) -> bool
+where
+    F: FnMut(&'a T) -> bool,
+{
+    for x in inner {
+        if f(x) {
+            return true;
+        }
+    }
+    for fragment in outer {
+        for x in fragment.iter() {
+            if f(x) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub fn fold<'a, T, B, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, init: B, mut f: F) -> B
+where
+    F: FnMut(B, &'a T) -> B,
+{
+    let mut res = inner.fold(init, &mut f);
+    for fragment in outer {
+        res = fragment.iter().fold(res, &mut f);
+    }
+    res
+}


### PR DESCRIPTION
More efficient versions of the following reduction methods are implemented for the iterator.
* `all`
* `any`
* `fold`