### PR TITLE
IntoIterator is required for PinnedVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.8"
+orx-pinned-vec = "2.9"
 
 [[bench]]
 name = "serial_access"

--- a/src/common_traits/iterator/into_iter.rs
+++ b/src/common_traits/iterator/into_iter.rs
@@ -1,0 +1,66 @@
+use crate::{Fragment, Growth, SplitVec};
+use std::iter::FusedIterator;
+
+impl<T, G: Growth> IntoIterator for SplitVec<T, G> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self.fragments)
+    }
+}
+
+/// An iterator that moves out of a vector.
+///
+/// This struct is created by the `into_iter` method on `SplitVec` (provided by the `IntoIterator` trait).
+pub struct IntoIter<T> {
+    outer: std::vec::IntoIter<Fragment<T>>,
+    inner: std::vec::IntoIter<T>,
+}
+
+impl<T> IntoIter<T> {
+    pub(crate) fn new(fragments: Vec<Fragment<T>>) -> Self {
+        let mut outer = fragments.into_iter();
+        let inner = outer
+            .next()
+            .map(|f| f.data.into_iter())
+            .unwrap_or(vec![].into_iter());
+
+        Self { outer, inner }
+    }
+
+    fn next_fragment(&mut self) -> Option<T> {
+        match self.outer.next() {
+            Some(f) => {
+                self.inner = f.data.into_iter();
+                self.next()
+            }
+            None => None,
+        }
+    }
+}
+
+impl<T: Clone> Clone for IntoIter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            outer: self.outer.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let next_element = self.inner.next();
+        if next_element.is_some() {
+            next_element
+        } else {
+            self.next_fragment()
+        }
+    }
+}
+
+impl<T> FusedIterator for IntoIter<T> {}

--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -1,7 +1,6 @@
+use super::reductions;
 use crate::fragment::fragment_struct::Fragment;
 use std::iter::FusedIterator;
-
-use super::reductions;
 
 /// Iterator over the `SplitVec`.
 ///

--- a/src/common_traits/iterator/mod.rs
+++ b/src/common_traits/iterator/mod.rs
@@ -1,5 +1,6 @@
 mod eq;
 mod from_iter;
+pub(crate) mod into_iter;
 pub(crate) mod iter;
 pub(crate) mod iter_mut;
 pub(crate) mod iter_mut_rev;

--- a/src/common_traits/iterator/reductions.rs
+++ b/src/common_traits/iterator/reductions.rs
@@ -8,38 +8,32 @@ pub fn all<'a, T, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, mut f: 
 where
     F: FnMut(&'a T) -> bool,
 {
-    for x in inner {
-        if !f(x) {
-            return false;
-        }
-    }
-    for fragment in outer {
-        for x in fragment.iter() {
-            if !f(x) {
+    if !inner.all(&mut f) {
+        false
+    } else {
+        for fragment in outer {
+            if !fragment.iter().all(&mut f) {
                 return false;
             }
         }
+        true
     }
-    true
 }
 
 pub fn any<'a, T, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, mut f: F) -> bool
 where
     F: FnMut(&'a T) -> bool,
 {
-    for x in inner {
-        if f(x) {
-            return true;
-        }
-    }
-    for fragment in outer {
-        for x in fragment.iter() {
-            if f(x) {
+    if inner.any(&mut f) {
+        true
+    } else {
+        for fragment in outer {
+            if fragment.iter().any(&mut f) {
                 return true;
             }
         }
+        false
     }
-    false
 }
 
 pub fn fold<'a, T, B, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, init: B, mut f: F) -> B

--- a/src/common_traits/iterator/tests/into_iter.rs
+++ b/src/common_traits/iterator/tests/into_iter.rs
@@ -1,0 +1,72 @@
+use crate::{test_all_growth_types, Growth, SplitVec};
+use orx_pinned_vec::PinnedVec;
+
+#[test]
+fn iter() {
+    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+        let n = 564;
+        let stdvec: Vec<_> = (0..n).collect();
+        vec.extend(stdvec);
+
+        for (i, x) in vec.into_iter().enumerate() {
+            assert_eq!(i, x);
+        }
+    }
+    test_all_growth_types!(test);
+}
+
+#[test]
+fn iter_empty_split_vec() {
+    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+        vec.clear();
+        let mut iter = vec.into_iter();
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
+    }
+    test_all_growth_types!(test);
+}
+
+#[test]
+fn iter_empty_first_fragment() {
+    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+        vec.clear();
+        vec.push(0);
+        _ = vec.pop();
+        assert!(vec.is_empty());
+
+        let mut iter = vec.into_iter();
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
+    }
+    test_all_growth_types!(test);
+}
+
+#[test]
+fn iter_one_fragment() {
+    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+        vec.clear();
+        vec.push(0);
+        vec.push(1);
+
+        assert_eq!(vec![0, 1], vec.into_iter().collect::<Vec<_>>());
+    }
+    test_all_growth_types!(test);
+}
+
+#[test]
+fn clone() {
+    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+        let n = 564;
+        let stdvec: Vec<_> = (0..n).collect();
+        vec.extend(stdvec);
+
+        let iter1 = vec.into_iter();
+        let iter2 = iter1.clone();
+
+        for (i, (a, b)) in iter1.zip(iter2).enumerate() {
+            assert_eq!(i, a);
+            assert_eq!(i, b);
+        }
+    }
+    test_all_growth_types!(test);
+}

--- a/src/common_traits/iterator/tests/mod.rs
+++ b/src/common_traits/iterator/tests/mod.rs
@@ -1,3 +1,4 @@
+mod into_iter;
 mod iter;
 mod iter_mut;
 mod iter_mut_rev;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,9 @@ pub(crate) mod test;
 /// Common relevant traits, structs, enums.
 pub mod prelude;
 
-pub use common_traits::iterator::iter::Iter;
+pub use common_traits::iterator::{
+    into_iter::IntoIter, iter::Iter, iter_mut::IterMut, iter_mut_rev::IterMutRev, iter_rev::IterRev,
+};
 pub use fragment::fragment_struct::Fragment;
 pub use fragment::into_fragments::IntoFragments;
 pub use growth::{


### PR DESCRIPTION
* Upgraded the orx-pinned-vec dependency to version 2.9 which requires all pinned vectors to implement `IntoIterator`.
* `IntoIter` is introduced and `IntoIterator` is implemented for `SplitVec`.
* Further, bug in `any` reduction is fixed.