### PR TITLE
slices and initialized grow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "2.12.0"
+version = "2.13.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "array", "split", "fragments", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.10"
+orx-pinned-vec = "2.11"
 
 [[bench]]
 name = "serial_access"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ An efficient constant access time vector with dynamic capacity and pinned elemen
 
 ## A. Motivation
 
-There are various situations where pinned elements are necessary.
+There are various situations where pinned elements are critical.
 
 * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+* It is important for **concurrent** programs as it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency, and leads to efficient concurrent data structures. See [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter), [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) or [`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) for such concurrent data structures which are conveniently built on the pinned element guarantees of pinned vectors.
 * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
-* It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 
 ## B. Comparison with `FixedVec`
 
@@ -19,7 +19,7 @@ There are various situations where pinned elements are necessary.
 
 | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
+| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`, etc. | Implements `PinnedVec` => can as well be wrapped by them.         |
 | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |
@@ -141,19 +141,19 @@ let slice = vec.try_get_slice(3..7);
 assert_eq!(slice, SplitVecSlice::OutOfBounds);
 
 // or the slice can be obtained as a vector of slices
-let slice = vec.slice(0..3);
-assert_eq!(1, slice.len());
-assert_eq!(slice[0], &[0, 1, 2]);
+let slices = vec.slices(0..3);
+assert_eq!(1, slices.len());
+assert_eq!(slices[0], &[0, 1, 2]);
 
-let slice = vec.slice(3..5);
-assert_eq!(2, slice.len());
-assert_eq!(slice[0], &[3]);
-assert_eq!(slice[1], &[4]);
+let slices = vec.slices(3..5);
+assert_eq!(2, slices.len());
+assert_eq!(slices[0], &[3]);
+assert_eq!(slices[1], &[4]);
 
-let slice = vec.slice(0..vec.len());
-assert_eq!(2, slice.len());
-assert_eq!(slice[0], &[0, 1, 2, 3]);
-assert_eq!(slice[1], &[4]);
+let slices = vec.slices(0..vec.len());
+assert_eq!(2, slices.len());
+assert_eq!(slices[0], &[0, 1, 2, 3]);
+assert_eq!(slices[1], &[4]);
 ```
 
 ### D.3. Pinned Elements

--- a/src/fragment/fragment_struct.rs
+++ b/src/fragment/fragment_struct.rs
@@ -24,6 +24,15 @@ impl<T> Fragment<T> {
         }
     }
 
+    /// Creates a new fragment with length and capacity equal to the given `capacity`, where each entry is filled with `f()`.
+    pub fn new_filled<F: Fn() -> T>(capacity: usize, f: F) -> Self {
+        let mut data = Vec::with_capacity(capacity);
+        for _ in 0..capacity {
+            data.push(f());
+        }
+        Self { data }
+    }
+
     /// Returns whether the fragment has room to push a new item or not.
     pub fn has_capacity_for_one(&self) -> bool {
         self.data.len() < self.data.capacity()

--- a/src/growth/doubling/doubling_growth.rs
+++ b/src/growth/doubling/doubling_growth.rs
@@ -87,6 +87,24 @@ impl Growth for Doubling {
         <Self as GrowthWithConstantTimeAccess>::get_ptr_mut(self, fragments, index)
     }
 
+    /// ***O(1)*** Returns a mutable reference to the `index`-th element of the split vector of the `fragments`
+    /// together with the index of the fragment that the element belongs to
+    /// and index of the element withing the respective fragment.
+    ///
+    /// Returns `None` if `index`-th position does not belong to the split vector; i.e., if `index` is out of cumulative capacity of fragments.
+    ///
+    /// # Safety
+    ///
+    /// This method allows to write to a memory which is greater than the split vector's length.
+    /// On the other hand, it will never return a pointer to a memory location that the vector does not own.
+    unsafe fn get_ptr_mut_and_indices<T>(
+        &self,
+        fragments: &mut [Fragment<T>],
+        index: usize,
+    ) -> Option<(*mut T, usize, usize)> {
+        <Self as GrowthWithConstantTimeAccess>::get_ptr_mut_and_indices(self, fragments, index)
+    }
+
     fn maximum_concurrent_capacity<T>(
         &self,
         fragments: &[Fragment<T>],

--- a/src/growth/linear/linear_growth.rs
+++ b/src/growth/linear/linear_growth.rs
@@ -85,6 +85,24 @@ impl Growth for Linear {
         <Self as GrowthWithConstantTimeAccess>::get_ptr_mut(self, fragments, index)
     }
 
+    /// ***O(1)*** Returns a mutable reference to the `index`-th element of the split vector of the `fragments`
+    /// together with the index of the fragment that the element belongs to
+    /// and index of the element withing the respective fragment.
+    ///
+    /// Returns `None` if `index`-th position does not belong to the split vector; i.e., if `index` is out of cumulative capacity of fragments.
+    ///
+    /// # Safety
+    ///
+    /// This method allows to write to a memory which is greater than the split vector's length.
+    /// On the other hand, it will never return a pointer to a memory location that the vector does not own.
+    unsafe fn get_ptr_mut_and_indices<T>(
+        &self,
+        fragments: &mut [Fragment<T>],
+        index: usize,
+    ) -> Option<(*mut T, usize, usize)> {
+        <Self as GrowthWithConstantTimeAccess>::get_ptr_mut_and_indices(self, fragments, index)
+    }
+
     fn maximum_concurrent_capacity<T>(
         &self,
         fragments: &[Fragment<T>],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@
 //!
 //! ## A. Motivation
 //!
-//! There are various situations where pinned elements are necessary.
+//! There are various situations where pinned elements are critical.
 //!
 //! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+//! * It is important for **concurrent** programs as it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency, and leads to efficient concurrent data structures. See [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter), [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) or [`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) for such concurrent data structures which are conveniently built on the pinned element guarantees of pinned vectors.
 //! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
-//! * It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 //!
 //! ## B. Comparison with `FixedVec`
 //!
@@ -19,7 +19,7 @@
 //!
 //! | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 //! |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-//! | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
+//! | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`, etc. | Implements `PinnedVec` => can as well be wrapped by them.         |
 //! | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 //! | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 //! | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |
@@ -141,19 +141,19 @@
 //! assert_eq!(slice, SplitVecSlice::OutOfBounds);
 //!
 //! // or the slice can be obtained as a vector of slices
-//! let slice = vec.slice(0..3);
-//! assert_eq!(1, slice.len());
-//! assert_eq!(slice[0], &[0, 1, 2]);
+//! let slices = vec.slices(0..3);
+//! assert_eq!(1, slices.len());
+//! assert_eq!(slices[0], &[0, 1, 2]);
 //!
-//! let slice = vec.slice(3..5);
-//! assert_eq!(2, slice.len());
-//! assert_eq!(slice[0], &[3]);
-//! assert_eq!(slice[1], &[4]);
+//! let slices = vec.slices(3..5);
+//! assert_eq!(2, slices.len());
+//! assert_eq!(slices[0], &[3]);
+//! assert_eq!(slices[1], &[4]);
 //!
-//! let slice = vec.slice(0..vec.len());
-//! assert_eq!(2, slice.len());
-//! assert_eq!(slice[0], &[0, 1, 2, 3]);
-//! assert_eq!(slice[1], &[4]);
+//! let slices = vec.slices(0..vec.len());
+//! assert_eq!(2, slices.len());
+//! assert_eq!(slices[0], &[0, 1, 2, 3]);
+//! assert_eq!(slices[1], &[4]);
 //! ```
 //!
 //! ### D.3. Pinned Elements
@@ -277,6 +277,7 @@ mod fragment;
 mod growth;
 mod new_split_vec;
 mod pinned_vec;
+mod range_helpers;
 mod resize_multiple;
 mod slice;
 mod split_vec;

--- a/src/range_helpers.rs
+++ b/src/range_helpers.rs
@@ -1,0 +1,42 @@
+use std::ops::RangeBounds;
+
+pub(crate) fn range_start<R: RangeBounds<usize>>(range: &R) -> usize {
+    match range.start_bound() {
+        std::ops::Bound::Excluded(x) => x + 1,
+        std::ops::Bound::Included(x) => *x,
+        std::ops::Bound::Unbounded => 0,
+    }
+}
+pub(crate) fn range_end<R: RangeBounds<usize>>(range: &R, vec_len: usize) -> usize {
+    match range.end_bound() {
+        std::ops::Bound::Excluded(x) => *x,
+        std::ops::Bound::Included(x) => x + 1,
+        std::ops::Bound::Unbounded => vec_len,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_all_growth_types, Growth, SplitVec};
+    use orx_pinned_vec::PinnedVec;
+
+    #[test]
+    fn range_start_end() {
+        fn test<G: Growth>(vec: SplitVec<usize, G>) {
+            assert_eq!(10, range_start(&(10..20)));
+            assert_eq!(10, range_start(&(10..=20)));
+            assert_eq!(0, range_start(&(..20)));
+            assert_eq!(10, range_start(&(10..)));
+            assert_eq!(0, range_start(&(..)));
+
+            assert_eq!(20, range_end(&(10..20), vec.len()));
+            assert_eq!(21, range_end(&(10..=20), vec.len()));
+            assert_eq!(20, range_end(&(..20), vec.len()));
+            assert_eq!(vec.len(), range_end(&(10..), vec.len()));
+            assert_eq!(vec.len(), range_end(&(..), vec.len()));
+        }
+
+        test_all_growth_types!(test);
+    }
+}

--- a/src/split_vec.rs
+++ b/src/split_vec.rs
@@ -1,3 +1,5 @@
+use orx_pinned_vec::PinnedVec;
+
 use crate::{fragment::fragment_struct::Fragment, Doubling, Growth};
 
 /// A split vector; i.e., a vector of fragments, with the following features:
@@ -190,6 +192,21 @@ where
     #[inline(always)]
     pub(crate) fn add_zeroed_fragment(&mut self) -> usize {
         self.add_fragment_get_fragment_capacity(true)
+    }
+
+    pub(crate) fn add_filled_fragment<F: Fn() -> T>(&mut self, f: F) -> usize {
+        assert_eq!(self.len(), self.capacity());
+
+        let new_fragment_capacity = self.growth.new_fragment_capacity(&self.fragments);
+        let new_len = self.len() + new_fragment_capacity;
+        self.fragments
+            .push(Fragment::new_filled(new_fragment_capacity, f));
+        unsafe { self.set_len(new_len) };
+
+        debug_assert_eq!(self.len(), new_len);
+        debug_assert_eq!(self.capacity(), new_len);
+
+        new_fragment_capacity
     }
 
     /// Adds a new fragment and return the capacity of the added (now last) fragment.

--- a/tests/grow_and_initialize.rs
+++ b/tests/grow_and_initialize.rs
@@ -1,0 +1,33 @@
+use orx_split_vec::prelude::*;
+
+#[test]
+fn grow_and_initialize() {
+    let mut vec = SplitVec::new();
+
+    for i in 0..2044 {
+        vec.push(i);
+    }
+    let capacity_before = vec.capacity();
+
+    let result = vec.grow_and_initialize(0, || 42);
+    assert_eq!(result, Ok(vec.capacity()));
+    assert_eq!(vec.capacity(), capacity_before);
+    assert_eq!(vec.len(), vec.capacity());
+    for i in 0..2044 {
+        assert_eq!(vec.get(i), Some(&i));
+    }
+    for i in 2044..vec.len() {
+        assert_eq!(vec.get(i), Some(&42));
+    }
+
+    let result = vec.grow_and_initialize(10000, || 42);
+    assert_eq!(result, Ok(vec.capacity()));
+    assert_eq!(vec.len(), vec.capacity());
+    assert!(vec.capacity() >= 10000);
+    for i in 0..2044 {
+        assert_eq!(vec.get(i), Some(&i));
+    }
+    for i in 2044..vec.len() {
+        assert_eq!(vec.get(i), Some(&42));
+    }
+}

--- a/tests/slices.rs
+++ b/tests/slices.rs
@@ -1,0 +1,31 @@
+use orx_split_vec::prelude::*;
+use test_case::test_matrix;
+
+fn slices<G: Growth>(mut vec: SplitVec<String, G>, len: usize) {
+    vec.clear();
+    vec.extend((0..len).map(|i| i.to_string()));
+
+    for i in 0..len {
+        let begin = i + 1;
+        let end = len.saturating_sub(1);
+        let slices = vec.slices(begin..end);
+        let mut val = begin;
+        for slice in slices {
+            for x in slice.iter() {
+                assert_eq!(x, &val.to_string());
+                val += 1;
+            }
+        }
+
+        if len > 0 {
+            assert_eq!(vec.get(0), Some(&(0.to_string())));
+        }
+    }
+}
+
+#[test_matrix([0, 1, 4, 5, 15, 16, 17, 1033])]
+fn test_slices(len: usize) {
+    slices(SplitVec::with_doubling_growth(), len);
+    slices(SplitVec::with_recursive_growth(), len);
+    slices(SplitVec::with_linear_growth(4), len);
+}

--- a/tests/slices_mut.rs
+++ b/tests/slices_mut.rs
@@ -1,0 +1,30 @@
+use orx_split_vec::prelude::*;
+use test_case::test_matrix;
+
+fn slices_mut<G: Growth>(mut vec: SplitVec<String, G>, len: usize) {
+    vec.clear();
+    vec.extend((0..len).map(|x| x.to_string()));
+
+    for i in 0..len {
+        let begin = i + 1;
+        let end = len.saturating_sub(1);
+        let slices = vec.slices_mut(begin..end);
+        for slice in slices {
+            for (i, x) in slice.iter_mut().enumerate() {
+                let _ = *x;
+                *x = i.to_string();
+            }
+        }
+
+        if len > 0 {
+            assert_eq!(vec.get(0), Some(&(0.to_string())));
+        }
+    }
+}
+
+#[test_matrix([0, 1, 4, 5, 15, 16, 17, 1033])]
+fn test_slices_mut(len: usize) {
+    slices_mut(SplitVec::with_doubling_growth(), len);
+    slices_mut(SplitVec::with_recursive_growth(), len);
+    slices_mut(SplitVec::with_linear_growth(4), len);
+}


### PR DESCRIPTION
Two slice returning methods are introduced. These methods are important in performant critical applications which allows to directly benefit from slice optimizations.
* `fn slices(&self, range: R)` returns an iterator of slices representing a given range of the vector.
* `fn slices_mut(&mut self, range: R)` returns a mutable iterator of slices representing a given range of the vector.

A concurrently safe growth method method `grow_and_initialize` is introduced. This methods performs capacity growth and length growth at the same time making sure that all elements are initialized with valid values.

Also unsafe `get_ptr_mut_and_indices` method is implemented.

Test methods are extended accordingly.