### PR TITLE
wasm tests added and linear growth overflow issue is fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ name = "serial_access"
 harness = false
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
-rand = "0.8"
-rand_chacha = "0.3"
+criterion = { version = "0.5", default-features = false }
+rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }
 test-case = "3.3.1"
+wasm-bindgen = "0.2"
+wasm-bindgen-test = "0.3"

--- a/src/growth/linear/constants.rs
+++ b/src/growth/linear/constants.rs
@@ -2,7 +2,15 @@ const fn fixed_capacity(const_size_power: usize) -> usize {
     usize::pow(2, const_size_power as u32)
 }
 
-pub(super) const FIXED_CAPACITIES: [usize; 32] = [
+const fn capacities_len() -> usize {
+    #[cfg(target_pointer_width = "32")]
+    return 29;
+
+    #[cfg(target_pointer_width = "64")]
+    return 32;
+}
+
+pub(super) const FIXED_CAPACITIES: [usize; capacities_len()] = [
     fixed_capacity(0),
     fixed_capacity(1),
     fixed_capacity(2),
@@ -32,7 +40,10 @@ pub(super) const FIXED_CAPACITIES: [usize; 32] = [
     fixed_capacity(26),
     fixed_capacity(27),
     fixed_capacity(28),
+    #[cfg(target_pointer_width = "64")]
     fixed_capacity(29),
+    #[cfg(target_pointer_width = "64")]
     fixed_capacity(30),
+    #[cfg(target_pointer_width = "64")]
     fixed_capacity(31),
 ];

--- a/src/growth/linear/linear_growth.rs
+++ b/src/growth/linear/linear_growth.rs
@@ -152,7 +152,9 @@ impl<T> SplitVec<T, Linear> {
     ///
     /// # Panics
     ///
-    /// Panics if `constant_fragment_capacity_exponent` is zero.
+    /// Panics if `constant_fragment_capacity_exponent` is not within:
+    /// * 1..32 for 64-bit platforms, or
+    /// * 1..29 for 32-bit platforms.
     ///
     /// # Examples
     ///
@@ -184,7 +186,8 @@ impl<T> SplitVec<T, Linear> {
     /// assert_eq!(Some(1), vec.fragments().last().map(|f| f.len()));
     /// ```
     pub fn with_linear_growth(constant_fragment_capacity_exponent: usize) -> Self {
-        assert!(constant_fragment_capacity_exponent > 0);
+        assert!(constant_fragment_capacity_exponent > 0 && constant_fragment_capacity_exponent < FIXED_CAPACITIES.len(),
+            "constant_fragment_capacity_exponent must be within 1..32 (1..29) for 64-bit (32-bit) platforms.");
 
         let constant_fragment_capacity = FIXED_CAPACITIES[constant_fragment_capacity_exponent];
         let fragments = Fragment::new(constant_fragment_capacity).into_fragments();

--- a/tests/growth_with_wasm32.rs
+++ b/tests/growth_with_wasm32.rs
@@ -1,0 +1,47 @@
+use orx_split_vec::*;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+const LEN: usize = 1 << 28;
+
+#[wasm_bindgen_test]
+fn grow_with_default_growth() {
+    grow_split_vec(SplitVec::new());
+}
+
+#[wasm_bindgen_test]
+fn grow_with_doubling() {
+    grow_split_vec(SplitVec::with_doubling_growth());
+    grow_split_vec(SplitVec::with_doubling_growth_and_fragments_capacity(32));
+}
+
+#[wasm_bindgen_test]
+fn grow_with_recursive() {
+    grow_split_vec(SplitVec::with_recursive_growth());
+    grow_split_vec(SplitVec::with_recursive_growth_and_fragments_capacity(32));
+}
+
+#[wasm_bindgen_test]
+fn grow_with_linear() {
+    grow_split_vec(SplitVec::with_linear_growth(10));
+    grow_split_vec(SplitVec::with_linear_growth(28));
+}
+
+#[wasm_bindgen_test]
+#[should_panic]
+fn grow_with_linear_panics_when_capacity_overflows() {
+    grow_split_vec(SplitVec::with_linear_growth(29));
+}
+
+fn grow_split_vec<G: Growth>(mut vec: SplitVec<u32, G>) {
+    assert!(vec.is_empty());
+
+    for i in 0..LEN {
+        vec.push(i as u32);
+    }
+
+    assert_eq!(vec.len(), LEN);
+
+    for i in 0..LEN {
+        assert_eq!(vec.get(i), Some(&(i as u32)));
+    }
+}


### PR DESCRIPTION
Overflow issue with `Linear` growth is fixed. `wasm_bindgen_test`s are added to test growth of the vector with different growth strategies.