### PR TITLE
concurrent clone and fill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "3.5.0"
+version = "3.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = "3.5"
+orx-pinned-vec = "3.6"
 
 [[bench]]
 name = "serial_access"

--- a/src/fragment/clone.rs
+++ b/src/fragment/clone.rs
@@ -1,0 +1,9 @@
+use crate::Fragment;
+
+impl<T: Clone> Clone for Fragment<T> {
+    fn clone(&self) -> Self {
+        let mut data = Vec::with_capacity(self.data.capacity());
+        data.extend(self.data.iter().cloned());
+        data.into()
+    }
+}

--- a/src/fragment/fragment_struct.rs
+++ b/src/fragment/fragment_struct.rs
@@ -1,6 +1,5 @@
-use crate::Growth;
-
-#[derive(Default, Clone)]
+#[derive(Default)]
+#[allow(clippy::include)]
 /// A contagious fragment of the split vector.
 ///
 /// Suppose a split vector contains 10 integers from 0 to 9.
@@ -92,50 +91,6 @@ pub(crate) unsafe fn set_fragments_len<T>(fragments: &mut [Fragment<T>], len: us
                 fragment.set_len(capacity);
                 remaining -= capacity;
             }
-        }
-    }
-}
-
-pub(crate) fn maximum_concurrent_capacity<G: Growth, T>(
-    fragments: &[Fragment<T>],
-    fragments_capacity: usize,
-    growth: &G,
-) -> usize {
-    assert!(fragments_capacity >= fragments.len());
-
-    match fragments_capacity == fragments.len() {
-        true => fragments.iter().map(|x| x.capacity()).sum(),
-        false => {
-            let mut capacities: Vec<_> = fragments.iter().map(|x| x.capacity()).collect();
-            for _ in fragments.len()..fragments_capacity {
-                let new_capacity = growth.new_fragment_capacity_from(capacities.iter().copied());
-                capacities.push(new_capacity);
-            }
-            capacities.iter().sum()
-        }
-    }
-}
-
-pub(crate) fn num_fragments_for_capacity<G: Growth, T>(
-    fragments: &[Fragment<T>],
-    growth: &G,
-    required_capacity: usize,
-) -> (usize, usize) {
-    let current_capacity: usize = fragments.iter().map(|x| x.capacity()).sum();
-
-    match current_capacity >= required_capacity {
-        true => (fragments.len(), current_capacity),
-        false => {
-            let mut num_fragments = fragments.len();
-            let mut capacities: Vec<_> = fragments.iter().map(|x| x.capacity()).collect();
-            let mut capacity = current_capacity;
-            while capacity < required_capacity {
-                let new_capacity = growth.new_fragment_capacity_from(capacities.iter().copied());
-                capacities.push(new_capacity);
-                capacity += new_capacity;
-                num_fragments += 1;
-            }
-            (num_fragments, capacity)
         }
     }
 }

--- a/src/fragment/mod.rs
+++ b/src/fragment/mod.rs
@@ -1,7 +1,9 @@
 mod as_ref;
+mod clone;
 mod debug;
 mod deref;
 mod eq;
 pub(crate) mod fragment_struct;
 mod from;
 pub(crate) mod into_fragments;
+pub(crate) mod transformations;

--- a/src/fragment/transformations.rs
+++ b/src/fragment/transformations.rs
@@ -1,0 +1,17 @@
+use crate::Fragment;
+use std::mem::ManuallyDrop;
+
+pub fn fragment_into_raw<T>(mut fragment: Fragment<T>) -> (*mut T, usize, usize) {
+    let (len, capacity) = (fragment.len(), fragment.capacity());
+    let ptr = fragment.as_mut_ptr();
+
+    let _ = ManuallyDrop::new(fragment);
+
+    (ptr, len, capacity)
+}
+
+pub unsafe fn fragment_from_raw<T>(ptr: *mut T, len: usize, capacity: usize) -> Fragment<T> {
+    assert!(capacity >= len);
+    let vec = Vec::from_raw_parts(ptr, len, capacity);
+    vec.into()
+}

--- a/src/growth/doubling/constants.rs
+++ b/src/growth/doubling/constants.rs
@@ -1,8 +1,11 @@
 pub(super) const FIRST_FRAGMENT_CAPACITY_POW: usize = 2;
-
 pub(super) const FIRST_FRAGMENT_CAPACITY: usize = usize::pow(2, FIRST_FRAGMENT_CAPACITY_POW as u32);
 pub(super) const SIZE_USIZE: usize = std::mem::size_of::<usize>() * 8;
 pub(super) const OFFSET_FRAGMENT_IDX: usize = SIZE_USIZE - FIRST_FRAGMENT_CAPACITY_POW - 1;
+
+const fn fragment_capacity(fragment_idx: usize) -> usize {
+    usize::pow(2, (fragment_idx + FIRST_FRAGMENT_CAPACITY_POW) as u32)
+}
 
 const fn cumulative_capacity(fragment_idx: usize) -> usize {
     usize::pow(2, (fragment_idx + FIRST_FRAGMENT_CAPACITY_POW + 1) as u32) - FIRST_FRAGMENT_CAPACITY
@@ -15,6 +18,44 @@ const fn capacities_len() -> usize {
     #[cfg(target_pointer_width = "64")]
     return 33;
 }
+
+pub(super) const CAPACITIES: [usize; capacities_len() - 1] = [
+    fragment_capacity(0),
+    fragment_capacity(1),
+    fragment_capacity(2),
+    fragment_capacity(3),
+    fragment_capacity(4),
+    fragment_capacity(5),
+    fragment_capacity(6),
+    fragment_capacity(7),
+    fragment_capacity(8),
+    fragment_capacity(9),
+    fragment_capacity(10),
+    fragment_capacity(11),
+    fragment_capacity(12),
+    fragment_capacity(13),
+    fragment_capacity(14),
+    fragment_capacity(15),
+    fragment_capacity(16),
+    fragment_capacity(17),
+    fragment_capacity(18),
+    fragment_capacity(19),
+    fragment_capacity(20),
+    fragment_capacity(21),
+    fragment_capacity(22),
+    fragment_capacity(23),
+    fragment_capacity(24),
+    fragment_capacity(25),
+    fragment_capacity(26),
+    fragment_capacity(27),
+    fragment_capacity(28),
+    #[cfg(target_pointer_width = "64")]
+    fragment_capacity(29),
+    #[cfg(target_pointer_width = "64")]
+    fragment_capacity(30),
+    #[cfg(target_pointer_width = "64")]
+    fragment_capacity(31),
+];
 
 pub(super) const CUMULATIVE_CAPACITIES: [usize; capacities_len()] = [
     0,

--- a/src/growth/doubling/doubling_growth.rs
+++ b/src/growth/doubling/doubling_growth.rs
@@ -156,6 +156,10 @@ impl GrowthWithConstantTimeAccess for Doubling {
         let f = OFFSET_FRAGMENT_IDX - leading_zeros;
         (f, element_index - CUMULATIVE_CAPACITIES[f])
     }
+
+    fn fragment_capacity_of(&self, fragment_index: usize) -> usize {
+        CAPACITIES[fragment_index]
+    }
 }
 
 impl<T> SplitVec<T, Doubling> {

--- a/src/growth/growth_trait.rs
+++ b/src/growth/growth_trait.rs
@@ -211,4 +211,7 @@ pub trait GrowthWithConstantTimeAccess: Growth {
             .get_mut(f)
             .map(|fragment| (fragment.as_mut_ptr().add(i), f, i))
     }
+
+    /// ***O(1)*** Returns the capacity of the fragment with the given `fragment_index`.
+    fn fragment_capacity_of(&self, fragment_index: usize) -> usize;
 }

--- a/src/growth/linear/linear_growth.rs
+++ b/src/growth/linear/linear_growth.rs
@@ -44,7 +44,8 @@ pub struct Linear {
 }
 
 impl Linear {
-    pub(crate) fn new(constant_fragment_capacity_exponent: usize) -> Self {
+    /// Creates a linear growth where each fragment will have a capacity of `2 ^ constant_fragment_capacity_exponent`.
+    pub fn new(constant_fragment_capacity_exponent: usize) -> Self {
         let constant_fragment_capacity = FIXED_CAPACITIES[constant_fragment_capacity_exponent];
         Self {
             constant_fragment_capacity_exponent,
@@ -141,6 +142,10 @@ impl GrowthWithConstantTimeAccess for Linear {
         let f = element_index >> self.constant_fragment_capacity_exponent;
         let i = element_index % self.constant_fragment_capacity;
         (f, i)
+    }
+
+    fn fragment_capacity_of(&self, _: usize) -> usize {
+        self.constant_fragment_capacity
     }
 }
 

--- a/src/into_concurrent_pinned_vec.rs
+++ b/src/into_concurrent_pinned_vec.rs
@@ -14,9 +14,14 @@ impl<T, G: GrowthWithConstantTimeAccess> IntoConcurrentPinnedVec<T> for SplitVec
     {
         if let Some(fragment) = self.fragments.last_mut() {
             let (len, capacity) = (fragment.len(), fragment.capacity());
-            for _ in len..capacity {
+            let num_additional = capacity - len;
+            for _ in 0..num_additional {
                 fragment.push(fill_with());
             }
+
+            self.len += num_additional;
+
+            debug_assert_eq!(self.len, self.fragments.iter().map(|x| x.len()).sum());
         }
 
         self.into()

--- a/tests/con_pinned_vec.rs
+++ b/tests/con_pinned_vec.rs
@@ -1,0 +1,52 @@
+use orx_split_vec::*;
+
+#[test]
+fn drop_con_pin_vec_after_into_inner() {
+    const LEN: usize = 1486;
+
+    fn test<G: GrowthWithConstantTimeAccess>(mut vec: SplitVec<String, G>) {
+        for i in 0..LEN {
+            vec.push(i.to_string());
+        }
+
+        let con_pinned_vec = vec.into_concurrent();
+
+        for i in 0..LEN {
+            let x = unsafe { con_pinned_vec.get(i) };
+            assert_eq!(x, Some(&i.to_string()));
+        }
+
+        let vec = unsafe { con_pinned_vec.into_inner(LEN) };
+
+        assert_eq!(vec.len(), LEN);
+        for i in 0..vec.len() {
+            assert_eq!(&vec[i], &i.to_string());
+        }
+    }
+
+    test(SplitVec::new());
+    test(SplitVec::with_doubling_growth_and_fragments_capacity(32));
+    test(SplitVec::with_linear_growth_and_fragments_capacity(10, 32));
+}
+
+#[test]
+fn drop_con_pin_vec_as_con_pin_vec() {
+    const LEN: usize = 1486;
+
+    fn test<G: GrowthWithConstantTimeAccess>(mut vec: SplitVec<String, G>) {
+        for i in 0..LEN {
+            vec.push(i.to_string());
+        }
+
+        let con_pinned_vec = vec.into_concurrent();
+
+        for i in 0..LEN {
+            let x = unsafe { con_pinned_vec.get(i) };
+            assert_eq!(x, Some(&i.to_string()));
+        }
+    }
+
+    test(SplitVec::new());
+    test(SplitVec::with_doubling_growth_and_fragments_capacity(32));
+    test(SplitVec::with_linear_growth_and_fragments_capacity(10, 32));
+}

--- a/tests/con_pinned_vec_grow.rs
+++ b/tests/con_pinned_vec_grow.rs
@@ -1,0 +1,104 @@
+use orx_split_vec::*;
+
+#[test]
+fn con_pin_vec_grow() {
+    const LEN: usize = 1486;
+
+    fn test<G: GrowthWithConstantTimeAccess>(vec: SplitVec<String, G>) {
+        assert_eq!(vec.fragments().len(), 1);
+
+        let growth = vec.growth().clone();
+
+        let mut num_fragments = 1;
+        let mut capacity = growth.fragment_capacity_of(0);
+
+        let con_pinned_vec = vec.into_concurrent();
+
+        for i in 0..LEN {
+            if i == capacity {
+                let new_fragment_capacity = growth.fragment_capacity_of(num_fragments);
+                let expected_new_capacity = capacity + new_fragment_capacity;
+
+                let new_capacity = con_pinned_vec.grow_to(capacity + 1).unwrap();
+                assert_eq!(new_capacity, expected_new_capacity);
+                assert_eq!(con_pinned_vec.capacity(), expected_new_capacity);
+
+                num_fragments += 1;
+                capacity = new_capacity;
+            }
+
+            let ptr = unsafe { con_pinned_vec.get_ptr_mut(i) };
+            unsafe { ptr.write(i.to_string()) };
+        }
+
+        for i in 0..LEN {
+            let x = unsafe { con_pinned_vec.get(i) };
+            assert_eq!(x, Some(&i.to_string()));
+        }
+
+        let vec = unsafe { con_pinned_vec.into_inner(LEN) };
+
+        assert_eq!(vec.len(), LEN);
+        for i in 0..vec.len() {
+            assert_eq!(&vec[i], &i.to_string());
+        }
+    }
+
+    test(SplitVec::with_doubling_growth_and_fragments_capacity(32));
+    test(SplitVec::with_linear_growth_and_fragments_capacity(10, 32));
+}
+
+#[test]
+fn con_pin_vec_grow_filled() {
+    const LEN: usize = 1486;
+
+    fn test<G: GrowthWithConstantTimeAccess>(vec: SplitVec<String, G>) {
+        assert_eq!(vec.fragments().len(), 1);
+
+        let growth = vec.growth().clone();
+
+        let mut num_fragments = 1;
+        let mut capacity = growth.fragment_capacity_of(0);
+
+        let con_pinned_vec = vec.into_concurrent();
+
+        for i in 0..LEN {
+            if i == capacity {
+                let new_fragment_capacity = growth.fragment_capacity_of(num_fragments);
+                let expected_new_capacity = capacity + new_fragment_capacity;
+
+                let new_capacity = con_pinned_vec
+                    .grow_to_and_fill_with(capacity + 1, || "x".to_string())
+                    .unwrap();
+                assert_eq!(new_capacity, expected_new_capacity);
+                assert_eq!(con_pinned_vec.capacity(), expected_new_capacity);
+
+                for i in capacity..new_capacity {
+                    let x = unsafe { con_pinned_vec.get(i) };
+                    assert_eq!(x, Some(&"x".to_string()));
+                }
+
+                num_fragments += 1;
+                capacity = new_capacity;
+            }
+
+            let ptr = unsafe { con_pinned_vec.get_ptr_mut(i) };
+            unsafe { ptr.write(i.to_string()) };
+        }
+
+        for i in 0..LEN {
+            let x = unsafe { con_pinned_vec.get(i) };
+            assert_eq!(x, Some(&i.to_string()));
+        }
+
+        let vec = unsafe { con_pinned_vec.into_inner(LEN) };
+
+        assert_eq!(vec.len(), LEN);
+        for i in 0..vec.len() {
+            assert_eq!(&vec[i], &i.to_string());
+        }
+    }
+
+    test(SplitVec::with_doubling_growth_and_fragments_capacity(32));
+    test(SplitVec::with_linear_growth_and_fragments_capacity(10, 32));
+}

--- a/tests/growth_constant_access.rs
+++ b/tests/growth_constant_access.rs
@@ -1,0 +1,24 @@
+use orx_split_vec::*;
+
+#[test]
+fn fragment_capacity_doubling() {
+    let growth = Doubling;
+
+    let mut capacity = 4;
+
+    for f in 0..31 {
+        assert_eq!(growth.fragment_capacity_of(f), capacity);
+        capacity *= 2;
+    }
+}
+
+#[test]
+fn fragment_capacity_linear() {
+    let growth = Linear::new(10);
+
+    let capacity = u32::pow(2, 10) as usize;
+
+    for f in 0..31 {
+        assert_eq!(growth.fragment_capacity_of(f), capacity);
+    }
+}


### PR DESCRIPTION
* clone_with_len is required for thread safe cloning of data.
* fill_with, on the other hand, is required for data structures that needs to be gap-free all the time.
* ConcurrentSplitVec is revised, refactored and simplified.
* Clone method is updated to make sure that the clone has the same capacity structure fulfilling the growth's requirements.
* Constant time `fragment_capacity_of` method is required and implemented for constant time growth strategies.
* Tests on drop of the concurrent vector are added.