### PR TITLE
reserve initialized maximum capacity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = "3.6"
+orx-pinned-vec = { path = "../orx-pinned-vec" }
 
 [[bench]]
 name = "serial_access"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = { path = "../orx-pinned-vec" }
+orx-pinned-vec = "3.7"
 
 [[bench]]
 name = "serial_access"

--- a/src/algorithms/in_place_sort.rs
+++ b/src/algorithms/in_place_sort.rs
@@ -5,7 +5,7 @@ pub fn in_place_sort_by<T, F>(fragments: &mut [Fragment<T>], mut compare: F)
 where
     F: FnMut(&T, &T) -> Ordering,
 {
-    if fragments.len() == 0 {
+    if fragments.is_empty() {
         return;
     }
 
@@ -60,9 +60,9 @@ where
         true => None,
         false => {
             let mut best = &fragments[r_best][0];
-            for q in (r_best + 1)..fragments.len() {
-                if let Less = compare(&fragments[q][0], best) {
-                    (best, r_best) = (&fragments[q][0], q);
+            for (q, fragment) in fragments.iter().enumerate().skip(r_best + 1) {
+                if let Less = compare(&fragment[0], best) {
+                    (best, r_best) = (&fragment[0], q);
                 }
             }
 

--- a/src/fragment/fragment_struct.rs
+++ b/src/fragment/fragment_struct.rs
@@ -1,5 +1,4 @@
 #[derive(Default)]
-#[allow(clippy::include)]
 /// A contagious fragment of the split vector.
 ///
 /// Suppose a split vector contains 10 integers from 0 to 9.


### PR DESCRIPTION
* ConcurrentSplitVec is simplified by removing the requirement for the atomic number of fragments. This number can be computed by the growth with constant time random access implementations.
* `reserve_maximum_concurrent_capacity_fill_with` is implemented.
* Tests related to reserving maximum capacity are extended.

Partially fixes #54