### PR TITLE
iter_over_range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "3.9.0"
+version = "3.10.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with dynamic capacity and pinned elements."
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "1.4", default-features = false }
-orx-pinned-vec = "3.9"
+orx-pinned-vec = "3.10"
 
 [[bench]]
 name = "serial_access"

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -266,6 +266,17 @@ impl<T, G: GrowthWithConstantTimeAccess> ConcurrentPinnedVec<T> for ConcurrentSp
         self.slices(0..len).into_iter().flat_map(|x| x.iter())
     }
 
+    unsafe fn iter_over_range<'a, R: RangeBounds<usize>>(
+        &'a self,
+        range: R,
+    ) -> impl Iterator<Item = &'a T> + 'a
+    where
+        T: 'a,
+    {
+        let [a, b] = orx_pinned_vec::utils::slice::vec_range_limits(&range, None);
+        self.slices(a..b).into_iter().flat_map(|x| x.iter())
+    }
+
     unsafe fn slices_mut<R: RangeBounds<usize>>(
         &self,
         range: R,

--- a/tests/con_iter_over_range.rs
+++ b/tests/con_iter_over_range.rs
@@ -1,0 +1,30 @@
+use orx_split_vec::*;
+
+#[test]
+fn iter_over_range() {
+    let vec = SplitVec::<_, Doubling>::from_iter([0, 1, 2, 3, 4, 5, 6].into_iter());
+    let con_vec = vec.into_concurrent();
+
+    unsafe {
+        let vec: Vec<_> = con_vec.iter_over_range(..7).copied().collect();
+        assert_eq!(vec, &[0, 1, 2, 3, 4, 5, 6]);
+
+        let vec: Vec<_> = con_vec.iter_over_range(..4).copied().collect();
+        assert_eq!(vec, &[0, 1, 2, 3]);
+
+        let vec: Vec<_> = con_vec.iter_over_range(1..7).copied().collect();
+        assert_eq!(vec, &[1, 2, 3, 4, 5, 6]);
+
+        let vec: Vec<_> = con_vec.iter_over_range(1..4).copied().collect();
+        assert_eq!(vec, &[1, 2, 3]);
+
+        let vec: Vec<_> = con_vec.iter_over_range(4..4).copied().collect();
+        assert_eq!(vec, &[]);
+
+        let vec: Vec<_> = con_vec.iter_over_range(4..3).copied().collect();
+        assert_eq!(vec, &[]);
+
+        let vec: Vec<_> = con_vec.iter_over_range(1..=4).copied().collect();
+        assert_eq!(vec, &[1, 2, 3, 4]);
+    }
+}


### PR DESCRIPTION
`iter_over_range` method is provided.

At one hand, `vec.iter_over_range(a..b)` is equivalent to `vec.iter().skip(a).take(b - a)`. However, the latter requires `a` unnecessary `next` calls. Since all pinned vectors provide random access to elements, the objective of `iter_over_range` is to directly jump to `a` and create an iterator from this point on, and hence, avoiding the unnecessary iterations at the beginning.