### PR TITLE
Iter revision

### DIFF
--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -54,10 +54,9 @@ impl<'a, T> Iterator for Iter<'a, T> {
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let next_element = self.inner.next();
-        if next_element.is_some() {
-            next_element
-        } else {
-            self.next_fragment()
+        match next_element.is_some() {
+            true => next_element,
+            false => self.next_fragment(),
         }
     }
 

--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -108,14 +108,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
         reductions::fold(&mut self.outer, &mut self.inner, init, f)
     }
 
-    fn is_sorted(mut self) -> bool
-    where
-        Self: Sized,
-        Self::Item: PartialOrd,
-    {
-        self.inner.is_sorted() && self.outer.all(|inner| inner.iter().is_sorted())
-    }
-
     fn last(self) -> Option<Self::Item>
     where
         Self: Sized,

--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -170,27 +170,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
         let len = self.remaining_len();
         (len, Some(len))
     }
-
-    fn skip(mut self, n: usize) -> Skip<Self>
-    where
-        Self: Sized,
-    {
-        let mut n = n;
-        while n >= self.inner.len() {
-            n -= self.inner.len();
-            match self.outer.next() {
-                Some(fragment) => self.inner = fragment.iter(),
-                None => self.inner = Default::default(),
-            }
-        }
-
-        let iter = Self {
-            inner: self.inner,
-            outer: self.outer,
-        };
-        todo!();
-        iter.skip(n)
-    }
 }
 
 impl<T> FusedIterator for Iter<'_, T> {}
@@ -213,17 +192,4 @@ where
         (Some(a), None) => Some(a),
         _ => b,
     }
-}
-
-#[test]
-fn abc() {
-    use crate::*;
-
-    let mut v = SplitVec::new();
-    v.push(1);
-    v.push(2);
-    v.push(3);
-
-    let mut iter = v.iter().skip(2);
-    assert_eq!(iter.next(), Some(&3333));
 }

--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -139,23 +139,27 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match self.inner.len() {
-            0 => None,
-            mut inner_len => {
-                let mut n = n;
-                while n >= inner_len {
-                    n -= self.inner.len();
-                    match self.outer.next() {
-                        Some(fragment) => {
-                            self.inner = fragment.iter();
-                            inner_len = fragment.len();
-                        }
-                        None => return None,
-                    }
-                }
-                self.inner.nth(n)
+        if self.inner.len() == 0 {
+            match self.outer.next() {
+                Some(fragment) => self.inner = fragment.iter(),
+                None => return None,
             }
         }
+
+        let mut inner_len = self.inner.len();
+        let mut n = n;
+        while n >= inner_len {
+            n -= inner_len;
+            match self.outer.next() {
+                Some(fragment) => {
+                    self.inner = fragment.iter();
+                    inner_len = fragment.len();
+                }
+                None => return None,
+            }
+        }
+
+        self.inner.nth(n)
     }
 
     fn reduce<F>(mut self, f: F) -> Option<Self::Item>

--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -1,6 +1,6 @@
 use super::reductions;
 use crate::{fragment::fragment_struct::Fragment, Growth, SplitVec};
-use core::iter::{FusedIterator, Skip};
+use core::iter::FusedIterator;
 
 impl<'a, T, G: Growth> IntoIterator for &'a SplitVec<T, G> {
     type Item = &'a T;

--- a/src/common_traits/iterator/iter.rs
+++ b/src/common_traits/iterator/iter.rs
@@ -139,15 +139,23 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let mut n = n;
-        while n >= self.inner.len() {
-            n -= self.inner.len();
-            match self.outer.next() {
-                Some(fragment) => self.inner = fragment.iter(),
-                None => self.inner = Default::default(),
+        match self.inner.len() {
+            0 => None,
+            mut inner_len => {
+                let mut n = n;
+                while n >= inner_len {
+                    n -= self.inner.len();
+                    match self.outer.next() {
+                        Some(fragment) => {
+                            self.inner = fragment.iter();
+                            inner_len = fragment.len();
+                        }
+                        None => return None,
+                    }
+                }
+                self.inner.nth(n)
             }
         }
-        self.inner.nth(n)
     }
 
     fn reduce<F>(mut self, f: F) -> Option<Self::Item>

--- a/src/common_traits/iterator/reductions.rs
+++ b/src/common_traits/iterator/reductions.rs
@@ -8,15 +8,9 @@ pub fn all<'a, T, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, mut f: 
 where
     F: FnMut(&'a T) -> bool,
 {
-    if !inner.all(&mut f) {
-        false
-    } else {
-        for fragment in outer {
-            if !fragment.iter().all(&mut f) {
-                return false;
-            }
-        }
-        true
+    match inner.all(&mut f) {
+        false => false,
+        true => !outer.any(|inner| !inner.iter().all(&mut f)),
     }
 }
 
@@ -24,15 +18,9 @@ pub fn any<'a, T, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, mut f: 
 where
     F: FnMut(&'a T) -> bool,
 {
-    if inner.any(&mut f) {
-        true
-    } else {
-        for fragment in outer {
-            if fragment.iter().any(&mut f) {
-                return true;
-            }
-        }
-        false
+    match inner.any(&mut f) {
+        true => true,
+        false => outer.any(|inner| inner.iter().any(&mut f)),
     }
 }
 

--- a/src/common_traits/iterator/reductions.rs
+++ b/src/common_traits/iterator/reductions.rs
@@ -28,9 +28,6 @@ pub fn fold<'a, T, B, F>(outer: &mut Outer<'a, T>, inner: &mut Inner<'a, T>, ini
 where
     F: FnMut(B, &'a T) -> B,
 {
-    let mut res = inner.fold(init, &mut f);
-    for fragment in outer {
-        res = fragment.iter().fold(res, &mut f);
-    }
-    res
+    let res = inner.fold(init, &mut f);
+    outer.fold(res, |res, inner| inner.iter().fold(res, &mut f))
 }

--- a/src/common_traits/iterator/reductions.rs
+++ b/src/common_traits/iterator/reductions.rs
@@ -31,3 +31,25 @@ where
     let res = inner.fold(init, &mut f);
     outer.fold(res, |res, inner| inner.iter().fold(res, &mut f))
 }
+
+pub fn reduce<'a, T, F>(
+    outer: &mut Outer<'a, T>,
+    inner: &mut Inner<'a, T>,
+    mut f: F,
+) -> Option<&'a T>
+where
+    F: FnMut(&'a T, &'a T) -> &'a T,
+{
+    match inner.len() {
+        0 => match outer.next() {
+            Some(inner) => inner
+                .iter()
+                .reduce(&mut f)
+                .map(|res| outer.fold(res, |res, inner| inner.iter().fold(res, &mut f))),
+            None => None,
+        },
+        _ => inner
+            .reduce(&mut f)
+            .map(|res| outer.fold(res, |res, inner| inner.iter().fold(res, &mut f))),
+    }
+}

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -1,6 +1,7 @@
 use crate::{test_all_growth_types, Growth, SplitVec};
 use alloc::vec::Vec;
 use orx_pinned_vec::*;
+use test_case::{test_case, test_matrix};
 
 #[test]
 fn iter() {
@@ -72,30 +73,28 @@ fn clone() {
     test_all_growth_types!(test);
 }
 
-#[test]
-fn all() {
-    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
-        let n = 564;
-        let std_vec: Vec<_> = (0..n).collect();
-        vec.extend(std_vec);
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 5, 27, 423]
+)]
+fn all(mut vec: SplitVec<usize, impl Growth>, n: usize) {
+    vec.clear();
+    vec.extend(0..n);
 
-        assert!(vec.iter().all(|x| *x as isize >= -1));
-        assert!(!vec.iter().all(|x| *x < 357));
-    }
-    test_all_growth_types!(test);
+    assert!(vec.iter().all(|x| *x as isize >= -1));
+    assert!(vec.is_empty() || !vec.iter().all(|x| *x < n - 1));
 }
 
-#[test]
-fn any() {
-    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
-        let n = 564;
-        let std_vec: Vec<_> = (0..n).collect();
-        vec.extend(std_vec);
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 5, 27, 423]
+)]
+fn any(mut vec: SplitVec<usize, impl Growth>, n: usize) {
+    vec.clear();
+    vec.extend(0..n);
 
-        assert!(!vec.iter().any(|x| *x as isize <= -1));
-        assert!(vec.iter().any(|x| *x < 357));
-    }
-    test_all_growth_types!(test);
+    assert!(!vec.iter().any(|x| *x as isize <= -1));
+    assert!(vec.is_empty() || vec.iter().any(|x| *x >= n / 2));
 }
 
 #[test]

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -55,24 +55,6 @@ fn iter_one_fragment() {
     test_all_growth_types!(test);
 }
 
-#[test]
-fn clone2() {
-    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
-        let n = 564;
-        let std_vec: Vec<_> = (0..n).collect();
-        vec.extend(std_vec);
-
-        let iter1 = vec.iter();
-        let iter2 = iter1.clone();
-
-        for (i, (a, b)) in iter1.zip(iter2).enumerate() {
-            assert_eq!(i, *a);
-            assert_eq!(i, *b);
-        }
-    }
-    test_all_growth_types!(test);
-}
-
 fn init_vec<G: Growth>(mut vec: SplitVec<usize, G>, n: usize) -> SplitVec<usize, G> {
     vec.clear();
     vec.extend(0..n);
@@ -83,7 +65,7 @@ fn init_vec<G: Growth>(mut vec: SplitVec<usize, G>, n: usize) -> SplitVec<usize,
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 3, 4, 5, 27, 423]
 )]
-fn clone(vec: SplitVec<usize, impl Growth>, n: usize) {
+fn clone_whole(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
 
     let iter1 = vec.iter();
@@ -92,6 +74,26 @@ fn clone(vec: SplitVec<usize, impl Growth>, n: usize) {
     for (i, (a, b)) in iter1.zip(iter2).enumerate() {
         assert_eq!(i, *a);
         assert_eq!(i, *b);
+    }
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 5, 8, 27, 423]
+)]
+fn clone_used(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let vec = init_vec(vec, n);
+    let num_used = n / 2;
+
+    let mut iter1 = vec.iter();
+    for _ in 0..num_used {
+        _ = iter1.next();
+    }
+    let iter2 = iter1.clone();
+
+    for (i, (a, b)) in iter1.zip(iter2).enumerate() {
+        assert_eq!(i + num_used, *a);
+        assert_eq!(i + num_used, *b);
     }
 }
 

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -161,6 +161,20 @@ fn fold(vec: SplitVec<usize, impl Growth>, n: usize) {
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 3, 4, 8, 5, 27, 423]
 )]
+fn last(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let vec = init_vec(vec, n);
+
+    let expected = match n {
+        0 => None,
+        _ => Some(n - 1),
+    };
+    assert_eq!(vec.iter().last().copied(), expected);
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 8, 5, 27, 423]
+)]
 fn reduce(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
 

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -227,6 +227,23 @@ fn min(vec: SplitVec<usize, impl Growth>, n: usize) {
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 3, 4, 8, 5, 27, 423]
 )]
+fn nth(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let vec = init_vec(vec, n);
+
+    let nth = [0, 3, 4, 8, 124, 99];
+    for nth in nth {
+        let expected = match nth < n {
+            true => Some(nth),
+            false => None,
+        };
+        assert_eq!(vec.iter().nth(nth).copied(), expected);
+    }
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 8, 5, 27, 423]
+)]
 fn reduce(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
 

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -120,3 +120,18 @@ fn fold() {
     }
     test_all_growth_types!(test);
 }
+
+#[test]
+fn reduce() {
+    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
+        let n = 564;
+        let std_vec: Vec<_> = (0..n).collect();
+        vec.extend(std_vec);
+
+        let sum = vec.iter().copied().reduce(|x, b| x + b);
+        let expected = (0..n).sum::<usize>();
+
+        assert_eq!(sum, Some(expected));
+    }
+    test_all_growth_types!(test);
+}

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -175,6 +175,32 @@ fn last(vec: SplitVec<usize, impl Growth>, n: usize) {
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 1, 3, 4, 5, 8, 27, 423]
 )]
+fn len(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let vec = init_vec(vec, n);
+
+    let mut len = n;
+    let mut iter = vec.iter();
+    while let Some(_) = iter.next() {
+        len -= 1;
+        assert_eq!(iter.len(), len);
+        assert_eq!(iter.size_hint(), (len, Some(len)));
+    }
+
+    assert_eq!(iter.len(), len);
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+
+    _ = iter.next();
+
+    assert_eq!(iter.len(), len);
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 1, 3, 4, 5, 8, 27, 423]
+)]
 fn max(vec: SplitVec<usize, impl Growth>, n: usize) {
     let mut vec = init_vec(vec, n);
 

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -1,5 +1,3 @@
-use std::dbg;
-
 use crate::{test_all_growth_types, Growth, SplitVec};
 use alloc::vec::Vec;
 use orx_pinned_vec::*;

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -1,3 +1,5 @@
+use std::dbg;
+
 use crate::{test_all_growth_types, Growth, SplitVec};
 use alloc::vec::Vec;
 use orx_pinned_vec::*;
@@ -63,7 +65,7 @@ fn init_vec<G: Growth>(mut vec: SplitVec<usize, G>, n: usize) -> SplitVec<usize,
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn clone_whole(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -99,7 +101,7 @@ fn clone_used(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn all(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -110,7 +112,7 @@ fn all(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn any(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -121,7 +123,7 @@ fn any(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn count(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -138,7 +140,7 @@ fn count(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn fold(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -159,7 +161,7 @@ fn fold(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn last(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -173,7 +175,7 @@ fn last(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn max(vec: SplitVec<usize, impl Growth>, n: usize) {
     let mut vec = init_vec(vec, n);
@@ -198,7 +200,7 @@ fn max(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn min(vec: SplitVec<usize, impl Growth>, n: usize) {
     let mut vec = init_vec(vec, n);
@@ -225,7 +227,7 @@ fn min(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423],
+    [0, 1, 3, 4, 5, 8, 27, 423],
     [0, 3, 4, 8, 124, 99]
 )]
 fn nth(vec: SplitVec<usize, impl Growth>, n: usize, nth: usize) {
@@ -240,7 +242,7 @@ fn nth(vec: SplitVec<usize, impl Growth>, n: usize, nth: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423],
+    [0, 1, 3, 4, 5, 8, 27, 423],
     [0, 3, 4, 8, 124, 99]
 )]
 fn nth_progressed(vec: SplitVec<usize, impl Growth>, n: usize, nth: usize) {
@@ -263,7 +265,7 @@ fn nth_progressed(vec: SplitVec<usize, impl Growth>, n: usize, nth: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 1, 3, 4, 5, 8, 27, 423]
 )]
 fn reduce(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -275,4 +277,41 @@ fn reduce(vec: SplitVec<usize, impl Growth>, n: usize) {
     };
 
     assert_eq!(sum, expected);
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 1, 3, 4, 5, 8, 27, 423],
+    [0, 3, 4, 8, 124, 99]
+)]
+fn skip(vec: SplitVec<usize, impl Growth>, n: usize, skip: usize) {
+    let vec = init_vec(vec, n);
+    let expected: usize = match skip < n {
+        true => (0..n).skip(skip).sum(),
+        false => 0,
+    };
+    assert_eq!(vec.iter().skip(skip).sum::<usize>(), expected);
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 1, 3, 4, 5, 8, 27, 423],
+    [0, 3, 4, 8, 124, 99]
+)]
+fn skip_progressed(vec: SplitVec<usize, impl Growth>, n: usize, skip: usize) {
+    let vec = init_vec(vec, n);
+    let mut iter = vec.iter();
+
+    let num_used = n / 2;
+    for _ in 0..num_used {
+        _ = iter.next();
+    }
+
+    let original_skip = num_used + skip;
+    let expected: usize = match original_skip < n {
+        true => (original_skip..n).sum(),
+        false => 0,
+    };
+
+    assert_eq!(iter.skip(skip).sum::<usize>(), expected);
 }

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -97,31 +97,47 @@ fn any(mut vec: SplitVec<usize, impl Growth>, n: usize) {
     assert!(vec.is_empty() || vec.iter().any(|x| *x >= n / 2));
 }
 
-#[test]
-fn fold() {
-    fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
-        let n = 564;
-        let std_vec: Vec<_> = (0..n).collect();
-        vec.extend(std_vec);
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 5, 27, 423]
+)]
+fn fold(mut vec: SplitVec<usize, impl Growth>, n: usize) {
+    vec.clear();
+    vec.extend(0..n);
 
-        let sum = vec.iter().fold(0isize, |x, b| {
-            if b % 2 == 0 {
-                x + *b as isize
-            } else {
-                x - *b as isize
-            }
-        });
+    let sum = vec.iter().fold(0isize, |x, b| {
+        if b % 2 == 0 {
+            x + *b as isize
+        } else {
+            x - *b as isize
+        }
+    });
 
-        let expected = (0..n).filter(|x| x % 2 == 0).sum::<usize>() as isize
-            - (0..n).filter(|x| x % 2 == 1).sum::<usize>() as isize;
+    let expected = (0..n).filter(|x| x % 2 == 0).sum::<usize>() as isize
+        - (0..n).filter(|x| x % 2 == 1).sum::<usize>() as isize;
 
-        assert_eq!(sum, expected);
-    }
-    test_all_growth_types!(test);
+    assert_eq!(sum, expected);
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 5, 27, 423]
+)]
+fn reduce(mut vec: SplitVec<usize, impl Growth>, n: usize) {
+    vec.clear();
+    vec.extend(0..n);
+
+    let sum = vec.iter().copied().reduce(|x, b| x + b);
+    let expected = match n {
+        0 => None,
+        _ => Some((0..n).sum::<usize>()),
+    };
+
+    assert_eq!(sum, expected);
 }
 
 #[test]
-fn reduce() {
+fn reduce2() {
     fn test<G: Growth>(mut vec: SplitVec<usize, G>) {
         let n = 564;
         let std_vec: Vec<_> = (0..n).collect();

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -63,7 +63,7 @@ fn init_vec<G: Growth>(mut vec: SplitVec<usize, G>, n: usize) -> SplitVec<usize,
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 5, 27, 423]
+    [0, 3, 4, 8, 5, 27, 423]
 )]
 fn clone_whole(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -99,7 +99,7 @@ fn clone_used(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 5, 27, 423]
+    [0, 3, 4, 8, 5, 27, 423]
 )]
 fn all(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -110,7 +110,7 @@ fn all(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 5, 27, 423]
+    [0, 3, 4, 8, 5, 27, 423]
 )]
 fn any(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -121,7 +121,24 @@ fn any(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 5, 27, 423]
+    [0, 3, 4, 8, 5, 27, 423]
+)]
+fn count(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let vec = init_vec(vec, n);
+    let num_used = n / 2;
+
+    assert_eq!(vec.iter().count(), n);
+
+    let mut iter = vec.iter();
+    for _ in 0..num_used {
+        _ = iter.next();
+    }
+    assert_eq!(iter.count(), n - num_used);
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 8, 5, 27, 423]
 )]
 fn fold(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
@@ -142,7 +159,7 @@ fn fold(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 5, 27, 423]
+    [0, 3, 4, 8, 5, 27, 423]
 )]
 fn reduce(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -65,7 +65,7 @@ fn init_vec<G: Growth>(mut vec: SplitVec<usize, G>, n: usize) -> SplitVec<usize,
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 1, 3, 4, 5, 8, 27, 423]
 )]
-fn clone_whole(vec: SplitVec<usize, impl Growth>, n: usize) {
+fn clone(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
 
     let iter1 = vec.iter();
@@ -81,7 +81,7 @@ fn clone_whole(vec: SplitVec<usize, impl Growth>, n: usize) {
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 3, 4, 5, 8, 27, 423]
 )]
-fn clone_used(vec: SplitVec<usize, impl Growth>, n: usize) {
+fn clone_progressed(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
     let num_used = n / 2;
 

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -175,6 +175,58 @@ fn last(vec: SplitVec<usize, impl Growth>, n: usize) {
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
     [0, 3, 4, 8, 5, 27, 423]
 )]
+fn max(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let mut vec = init_vec(vec, n);
+
+    let expected = match n {
+        0 => None,
+        _ => Some(n - 1),
+    };
+    assert_eq!(vec.iter().max().copied(), expected);
+
+    if let Some(x) = vec.get_mut(n / 2) {
+        *x = n + 1;
+        assert_eq!(vec.iter().max().copied(), Some(n + 1));
+    };
+
+    let mut vec = init_vec(vec, n);
+    if let Some(x) = vec.get_mut(4) {
+        *x = n + 1;
+        assert_eq!(vec.iter().max().copied(), Some(n + 1));
+    };
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 8, 5, 27, 423]
+)]
+fn min(vec: SplitVec<usize, impl Growth>, n: usize) {
+    let mut vec = init_vec(vec, n);
+
+    let expected = match n {
+        0 => None,
+        _ => Some(0),
+    };
+    assert_eq!(vec.iter().min().copied(), expected);
+
+    for x in vec.iter_mut() {
+        *x += n;
+    }
+    if let Some(x) = vec.get_mut(n / 2) {
+        *x = 1;
+        assert_eq!(vec.iter().min().copied(), Some(1));
+    };
+
+    if let Some(x) = vec.get_mut(4) {
+        *x = 0;
+        assert_eq!(vec.iter().min().copied(), Some(0));
+    };
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 8, 5, 27, 423]
+)]
 fn reduce(vec: SplitVec<usize, impl Growth>, n: usize) {
     let vec = init_vec(vec, n);
 

--- a/src/common_traits/iterator/tests/iter.rs
+++ b/src/common_traits/iterator/tests/iter.rs
@@ -225,19 +225,40 @@ fn min(vec: SplitVec<usize, impl Growth>, n: usize) {
 
 #[test_matrix(
     [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
-    [0, 3, 4, 8, 5, 27, 423]
+    [0, 3, 4, 8, 5, 27, 423],
+    [0, 3, 4, 8, 124, 99]
 )]
-fn nth(vec: SplitVec<usize, impl Growth>, n: usize) {
+fn nth(vec: SplitVec<usize, impl Growth>, n: usize, nth: usize) {
     let vec = init_vec(vec, n);
 
-    let nth = [0, 3, 4, 8, 124, 99];
-    for nth in nth {
-        let expected = match nth < n {
-            true => Some(nth),
-            false => None,
-        };
-        assert_eq!(vec.iter().nth(nth).copied(), expected);
+    let expected = match nth < n {
+        true => Some(nth),
+        false => None,
+    };
+    assert_eq!(vec.iter().nth(nth).copied(), expected);
+}
+
+#[test_matrix(
+    [SplitVec::with_doubling_growth(), SplitVec::with_linear_growth(2), SplitVec::with_recursive_growth()],
+    [0, 3, 4, 8, 5, 27, 423],
+    [0, 3, 4, 8, 124, 99]
+)]
+fn nth_progressed(vec: SplitVec<usize, impl Growth>, n: usize, nth: usize) {
+    let vec = init_vec(vec, n);
+
+    let mut iter = vec.iter();
+    let num_used = n / 2;
+    for _ in 0..num_used {
+        _ = iter.next();
     }
+
+    let original_nth = num_used + nth;
+    let expected = match original_nth < n {
+        true => Some(original_nth),
+        false => None,
+    };
+
+    assert_eq!(iter.nth(nth).copied(), expected);
 }
 
 #[test_matrix(

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 macro_rules! test_all_growth_types {
     ($fun:tt) => {
-        $fun::<$crate::Linear>(SplitVec::with_linear_growth(2));
+        $fun::<$crate::Linear>(SplitVec::with_linear_growth(8));
         $fun::<$crate::Doubling>(SplitVec::with_doubling_growth());
         $fun::<$crate::Recursive>(SplitVec::with_recursive_growth());
     };


### PR DESCRIPTION
Necessary Iterator methods are overwritten in order to improve performance:

* `nth` is implemented. This also improves the performance of `skip`. Fixes #75 
* `last` method is implemented to avoid iterating the entire range.
* `max` and `min` are implemented to reduce over the fragments' default reductions.
* Similarly, reduction methods `fold`, `reduce`, `all`, `any`, `count` are implemented.

In addition, `Clone` is implemented for the split vector iterator.

Finally, `ExactSizeIterator` is implemented.
