### PR TITLE
upgrade pinned vec and concurrent iter versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-split-vec"
-version = "3.21.0"
+version = "3.22.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient dynamic capacity vector with pinned element guarantees."
@@ -12,8 +12,8 @@ categories = ["data-structures", "rust-patterns", "no-std"]
 [dependencies]
 orx-iterable = { version = "1.3.0", default-features = false }
 orx-pseudo-default = { version = "2.1.0", default-features = false }
-orx-pinned-vec = { version = "3.20.0", default-features = false }
-orx-concurrent-iter = { version = "3.1.0", default-features = false }
+orx-pinned-vec = { version = "3.21.0", default-features = false }
+orx-concurrent-iter = { version = "3.3.0", default-features = false }
 
 [[bench]]
 name = "serial_access"


### PR DESCRIPTION
Upgrades `PinnedVec` for improved safety guarantees: https://github.com/orxfun/orx-pinned-vec/releases/tag/3.21.0

Upgrades `ConcurrentIter` for fused iterator behavior of the concurrent iter implementation: https://github.com/orxfun/orx-concurrent-iter/releases/tag/3.3.0
